### PR TITLE
refactor(styling): restructure tokens and update widgets

### DIFF
--- a/example/lib/styling.dart
+++ b/example/lib/styling.dart
@@ -172,6 +172,11 @@ class Styling extends InheritedWidget {
     required super.child,
   });
 
+  // Static - no context needed
+  static RadiusTokens get radii => _radii;
+  static DurationTokens get durations => _durations;
+  static BreakpointTokens get breakpoints => _breakpoints;
+
   static StylingData of(BuildContext context) {
     final Styling? styling = context
         .dependOnInheritedWidgetOfExactType<Styling>();

--- a/example/lib/styling.dart
+++ b/example/lib/styling.dart
@@ -1,97 +1,144 @@
 import 'package:flutter/widgets.dart';
 
-// GLOBALS
+// ============================================================================
+// CUSTOMIZE THESE VALUES
+// ============================================================================
+
+// Breakpoints
+const double _desktopBreakpoint = 600;
+
+// Light Theme - Base
+const Color _lightBackground = Color(0xFFFFFFFF);
+const Color _lightBorder = Color(0xFFE4E4E7);
+const Color _lightPrimaryText = Color(0xFF2A2A2A);
+const Color _lightSecondaryText = Color(0xFFACAEAF);
+
+// Light Theme - Button
+const Color _lightButtonPrimary = Color(0xFF18181B);
+const Color _lightButtonPrimaryForeground = Color(0xFFFAFAFA);
+const Color _lightButtonSecondary = Color(0xFFF4F4F5);
+const Color _lightButtonSecondaryForeground = Color(0xFF18181B);
+const Color _lightButtonDestructive = Color(0xFFEF4444);
+const Color _lightButtonDestructiveForeground = Color(0xFFFAFAFA);
+const Color _lightButtonLink = Color(0xFF3B82F6);
+const Color _lightButtonAccent = Color(0xFFF4F4F5);
+
+// Light Theme - Navigation
+const Color _lightNavRailBackground = Color(0xFFFAFAFA);
+const Color _lightNavRailItemBackgroundActive = Color(0xFFFFFFFF);
+const Color _lightNavRailItemBackgroundHover = Color(0xFFF2F2F2);
+const Color _lightNavRailItemText = Color(0xFF2A2A2A);
+const Color _lightNavBottomBarBackground = Color(0xFFFFFFFF);
+const Color _lightNavBottomBarItemActive = Color(0xFF121212);
+const Color _lightNavBottomBarItemInactive = Color(0xFFBBBBBB);
+
+// Light Theme - Toast
+const Color _lightToastSuccess = Color(0xFF52DF82);
+const Color _lightToastError = Color(0xFFFF6D62);
+const Color _lightToastInfo = Color(0xFF529BDF);
+const Color _lightToastWarning = Color(0xFFFFB35A);
+
+// Dark Theme - Base
+const Color _darkBackground = Color(0xFF303030);
+const Color _darkBorder = Color(0xFF27272A);
+const Color _darkPrimaryText = Color(0xFFFAFAFA);
+const Color _darkSecondaryText = Color(0xFFB2B2B2);
+
+// Dark Theme - Button
+const Color _darkButtonPrimary = Color(0xFFFAFAFA);
+const Color _darkButtonPrimaryForeground = Color(0xFF18181B);
+const Color _darkButtonSecondary = Color(0xFF27272A);
+const Color _darkButtonSecondaryForeground = Color(0xFFFAFAFA);
+const Color _darkButtonDestructive = Color(0xFFEF4444);
+const Color _darkButtonDestructiveForeground = Color(0xFFFAFAFA);
+const Color _darkButtonLink = Color(0xFF60A5FA);
+const Color _darkButtonAccent = Color(0xFF27272A);
+
+// Dark Theme - Navigation
+const Color _darkNavRailBackground = Color(0xFF121212);
+const Color _darkNavRailItemBackgroundActive = Color(0xFF2A2A2A);
+const Color _darkNavRailItemBackgroundHover = Color(0xFF080808);
+const Color _darkNavRailItemText = Color(0xFFFAFAFA);
+const Color _darkNavBottomBarBackground = Color(0xFF121212);
+const Color _darkNavBottomBarItemActive = Color(0xFFFAFAFA);
+const Color _darkNavBottomBarItemInactive = Color(0xFF71717A);
+
+// Dark Theme - Toast
+const Color _darkToastSuccess = Color(0xFF52DF82);
+const Color _darkToastError = Color(0xFFFF6D62);
+const Color _darkToastInfo = Color(0xFF529BDF);
+const Color _darkToastWarning = Color(0xFFFFB35A);
+
+// ============================================================================
+// INTERNAL - NO NEED TO EDIT BELOW
+// ============================================================================
+
 final Breakpoints _breakpoints = Breakpoints(
-  desktop: 600,
+  desktop: _desktopBreakpoint,
 );
 
-// LIGHT
-const Color _backgroundLight = Color(0xFFFFFFFF);
-const Color _borderLight = Color(0xFFE4E4E7);
-const Color _primaryTextLight = Color(0xff2A2A2A);
-const Color _secondaryTextLight = Color(0xffACAEAF);
-
-final ButtonColors _buttonColorsLight = ButtonColors(
-  primary: const Color(0xFF18181B),
-  primaryForeground: const Color(0xFFFAFAFA),
-  secondary: const Color(0xFFF4F4F5),
-  secondaryForeground: const Color(0xFF18181B),
-  destructive: const Color(0xFFEF4444),
-  destructiveForeground: const Color(0xFFFAFAFA),
-  link: const Color(0xFF3B82F6),
-  accent: const Color(0xFFF4F4F5),
+final AppColors _colorsLight = AppColors(
+  background: _lightBackground,
+  border: _lightBorder,
+  primaryText: _lightPrimaryText,
+  secondaryText: _lightSecondaryText,
+  button: ButtonColors(
+    primary: _lightButtonPrimary,
+    primaryForeground: _lightButtonPrimaryForeground,
+    secondary: _lightButtonSecondary,
+    secondaryForeground: _lightButtonSecondaryForeground,
+    destructive: _lightButtonDestructive,
+    destructiveForeground: _lightButtonDestructiveForeground,
+    link: _lightButtonLink,
+    accent: _lightButtonAccent,
+  ),
+  navigation: NavigationColors(
+    railBackground: _lightNavRailBackground,
+    railItemBackgroundActive: _lightNavRailItemBackgroundActive,
+    railItemBackgroundHover: _lightNavRailItemBackgroundHover,
+    railItemText: _lightNavRailItemText,
+    bottomBarBackground: _lightNavBottomBarBackground,
+    bottomBarItemActive: _lightNavBottomBarItemActive,
+    bottomBarItemInactive: _lightNavBottomBarItemInactive,
+  ),
+  toast: ToastColors(
+    success: _lightToastSuccess,
+    error: _lightToastError,
+    info: _lightToastInfo,
+    warning: _lightToastWarning,
+  ),
 );
 
-final NavigationColors _navigationColorsLight = NavigationColors(
-  railBackground: const Color(0xFFFAFAFA),
-  railItemBackgroundActive: const Color(0xFFFFFFFF),
-  railItemBackgroundHover: const Color(0xFFF2F2F2),
-  railItemText: const Color(0xFF2A2A2A),
-  bottomBarBackground: const Color(0xFFFFFFFF),
-  bottomBarItemActive: const Color(0xFF121212),
-  bottomBarItemInactive: const Color(0xFFBBBBBB),
-);
-
-const ToastColors _toastColorsLight = ToastColors(
-  success: Color(0xFF52DF82),
-  error: Color(0xFFFF6D62),
-  info: Color(0xFF529BDF),
-  warning: Color(0xFFFFB35A),
-);
-
-// DARK
-const Color _backgroundDark = Color(0xFF303030);
-const Color _borderDark = Color(0xFF27272A);
-const Color _primaryTextDark = Color(0xffFAFAFA);
-const Color _secondaryTextDark = Color(0xffB2B2B2);
-
-final ButtonColors _buttonColorsDark = ButtonColors(
-  primary: Color(0xFFFAFAFA),
-  primaryForeground: Color(0xFF18181B),
-  secondary: Color(0xFF27272A),
-  secondaryForeground: Color(0xFFFAFAFA),
-  destructive: Color(0xFFEF4444),
-  destructiveForeground: Color(0xFFFAFAFA),
-  link: Color(0xFF60A5FA),
-  accent: Color(0xFF27272A),
-);
-
-final NavigationColors _navigationColorsDark = NavigationColors(
-  railBackground: Color(0xFF121212),
-  railItemBackgroundActive: Color(0xFF2A2A2A),
-  railItemBackgroundHover: Color(0xFF080808),
-  railItemText: Color(0xFFFAFAFA),
-  bottomBarBackground: Color(0xFF121212),
-  bottomBarItemActive: Color(0xFFFAFAFA),
-  bottomBarItemInactive: Color(0xFF71717A),
-);
-
-const ToastColors _toastColorsDark = ToastColors(
-  success: Color(0xFF52DF82),
-  error: Color(0xFFFF6D62),
-  info: Color(0xFF529BDF),
-  warning: Color(0xFFFFB35A),
-);
-
-// NO TOUCHING
-final AppColors _appColorsLight = AppColors(
-  background: _backgroundLight,
-  border: _borderLight,
-  primaryText: _primaryTextLight,
-  secondaryText: _secondaryTextLight,
-  navigation: _navigationColorsLight,
-  button: _buttonColorsLight,
-  toast: _toastColorsLight,
-);
-
-final AppColors _appColorsDark = AppColors(
-  background: _backgroundDark,
-  border: _borderDark,
-  primaryText: _primaryTextDark,
-  secondaryText: _secondaryTextDark,
-  button: _buttonColorsDark,
-  navigation: _navigationColorsDark,
-  toast: _toastColorsDark,
+final AppColors _colorsDark = AppColors(
+  background: _darkBackground,
+  border: _darkBorder,
+  primaryText: _darkPrimaryText,
+  secondaryText: _darkSecondaryText,
+  button: ButtonColors(
+    primary: _darkButtonPrimary,
+    primaryForeground: _darkButtonPrimaryForeground,
+    secondary: _darkButtonSecondary,
+    secondaryForeground: _darkButtonSecondaryForeground,
+    destructive: _darkButtonDestructive,
+    destructiveForeground: _darkButtonDestructiveForeground,
+    link: _darkButtonLink,
+    accent: _darkButtonAccent,
+  ),
+  navigation: NavigationColors(
+    railBackground: _darkNavRailBackground,
+    railItemBackgroundActive: _darkNavRailItemBackgroundActive,
+    railItemBackgroundHover: _darkNavRailItemBackgroundHover,
+    railItemText: _darkNavRailItemText,
+    bottomBarBackground: _darkNavBottomBarBackground,
+    bottomBarItemActive: _darkNavBottomBarItemActive,
+    bottomBarItemInactive: _darkNavBottomBarItemInactive,
+  ),
+  toast: ToastColors(
+    success: _darkToastSuccess,
+    error: _darkToastError,
+    info: _darkToastInfo,
+    warning: _darkToastWarning,
+  ),
 );
 
 class Styling extends InheritedWidget {
@@ -104,8 +151,8 @@ class Styling extends InheritedWidget {
   });
 
   static StylingData of(BuildContext context) {
-    final Styling? styling = context
-        .dependOnInheritedWidgetOfExactType<Styling>();
+    final Styling? styling =
+        context.dependOnInheritedWidgetOfExactType<Styling>();
 
     assert(
       styling != null,
@@ -116,7 +163,7 @@ class Styling extends InheritedWidget {
 
     return StylingData(
       isDark: isDark,
-      colors: isDark ? _appColorsDark : _appColorsLight,
+      colors: isDark ? _colorsDark : _colorsLight,
       breakpoints: _breakpoints,
     );
   }
@@ -132,7 +179,7 @@ class StylingData {
   final AppColors colors;
   final Breakpoints breakpoints;
 
-  StylingData({
+  const StylingData({
     required this.isDark,
     required this.colors,
     required this.breakpoints,
@@ -208,8 +255,6 @@ class AppColors {
   final Color border;
   final Color primaryText;
   final Color secondaryText;
-
-  // Component colors
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;

--- a/example/lib/styling.dart
+++ b/example/lib/styling.dart
@@ -7,6 +7,16 @@ import 'package:flutter/widgets.dart';
 // Breakpoints
 const double _desktopBreakpoint = 600;
 
+// Radii
+const double _radiusSmall = 8;
+const double _radiusMedium = 12;
+const double _radiusLarge = 24;
+
+// Durations
+const Duration _durationFast = Duration(milliseconds: 100);
+const Duration _durationNormal = Duration(milliseconds: 200);
+const Duration _durationSlow = Duration(milliseconds: 300);
+
 // Light Theme - Base
 const Color _lightBackground = Color(0xFFFFFFFF);
 const Color _lightBorder = Color(0xFFE4E4E7);
@@ -73,11 +83,23 @@ const Color _darkToastWarning = Color(0xFFFFB35A);
 // INTERNAL - NO NEED TO EDIT BELOW
 // ============================================================================
 
-final Breakpoints _breakpoints = Breakpoints(
+final BreakpointTokens _breakpoints = BreakpointTokens(
   desktop: _desktopBreakpoint,
 );
 
-final AppColors _colorsLight = AppColors(
+final RadiusTokens _radii = RadiusTokens(
+  small: _radiusSmall,
+  medium: _radiusMedium,
+  large: _radiusLarge,
+);
+
+final DurationTokens _durations = DurationTokens(
+  fast: _durationFast,
+  normal: _durationNormal,
+  slow: _durationSlow,
+);
+
+final ColorTokens _colorsLight = ColorTokens(
   background: _lightBackground,
   border: _lightBorder,
   primaryText: _lightPrimaryText,
@@ -109,7 +131,7 @@ final AppColors _colorsLight = AppColors(
   ),
 );
 
-final AppColors _colorsDark = AppColors(
+final ColorTokens _colorsDark = ColorTokens(
   background: _darkBackground,
   border: _darkBorder,
   primaryText: _darkPrimaryText,
@@ -151,8 +173,8 @@ class Styling extends InheritedWidget {
   });
 
   static StylingData of(BuildContext context) {
-    final Styling? styling =
-        context.dependOnInheritedWidgetOfExactType<Styling>();
+    final Styling? styling = context
+        .dependOnInheritedWidgetOfExactType<Styling>();
 
     assert(
       styling != null,
@@ -164,6 +186,8 @@ class Styling extends InheritedWidget {
     return StylingData(
       isDark: isDark,
       colors: isDark ? _colorsDark : _colorsLight,
+      radii: _radii,
+      durations: _durations,
       breakpoints: _breakpoints,
     );
   }
@@ -176,21 +200,49 @@ class Styling extends InheritedWidget {
 
 class StylingData {
   final bool isDark;
-  final AppColors colors;
-  final Breakpoints breakpoints;
+  final ColorTokens colors;
+  final RadiusTokens radii;
+  final DurationTokens durations;
+  final BreakpointTokens breakpoints;
 
   const StylingData({
     required this.isDark,
     required this.colors,
+    required this.radii,
+    required this.durations,
     required this.breakpoints,
   });
 }
 
-class Breakpoints {
+class BreakpointTokens {
   final double desktop;
 
-  const Breakpoints({
+  const BreakpointTokens({
     required this.desktop,
+  });
+}
+
+class RadiusTokens {
+  final double small;
+  final double medium;
+  final double large;
+
+  const RadiusTokens({
+    required this.small,
+    required this.medium,
+    required this.large,
+  });
+}
+
+class DurationTokens {
+  final Duration fast;
+  final Duration normal;
+  final Duration slow;
+
+  const DurationTokens({
+    required this.fast,
+    required this.normal,
+    required this.slow,
   });
 }
 
@@ -250,7 +302,7 @@ class ToastColors {
   });
 }
 
-class AppColors {
+class ColorTokens {
   final Color background;
   final Color border;
   final Color primaryText;
@@ -259,7 +311,7 @@ class AppColors {
   final NavigationColors navigation;
   final ToastColors toast;
 
-  const AppColors({
+  const ColorTokens({
     required this.background,
     required this.border,
     required this.primaryText,

--- a/example/lib/widgets/alert_popup.dart
+++ b/example/lib/widgets/alert_popup.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
+final Duration _animationDuration = Styling.durations.normal;
 
 class AlertPopup extends StatelessWidget {
   final Widget? icon;
@@ -53,7 +53,7 @@ class AlertPopup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/example/lib/widgets/button.dart
+++ b/example/lib/widgets/button.dart
@@ -47,7 +47,7 @@ class _ButtonState extends State<Button> with SingleTickerProviderStateMixin {
     super.initState();
 
     _clickAnimationController = AnimationController(
-      duration: const Duration(milliseconds: 100),
+      duration: Styling.durations.fast,
       vsync: this,
     );
 
@@ -185,7 +185,7 @@ class _ButtonState extends State<Button> with SingleTickerProviderStateMixin {
                         : null,
                     borderRadius: widget.variant == ButtonVariant.link
                         ? null
-                        : BorderRadius.circular(12),
+                        : BorderRadius.circular(Styling.radii.medium),
                     boxShadow: _isFocused && !isDisabled
                         ? [
                             BoxShadow(

--- a/example/lib/widgets/confirmation_popup.dart
+++ b/example/lib/widgets/confirmation_popup.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
+final Duration _animationDuration = Styling.durations.normal;
 
 class ConfirmationPopup extends StatelessWidget {
   final Widget? icon;
@@ -70,7 +70,7 @@ class ConfirmationPopup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/example/lib/widgets/nav_bar.dart
+++ b/example/lib/widgets/nav_bar.dart
@@ -169,7 +169,7 @@ class _RailItemState extends State<_RailItem> {
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
             decoration: BoxDecoration(
               color: backgroundColor,
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: BorderRadius.circular(Styling.radii.medium),
             ),
             child: Row(
               children: [

--- a/example/lib/widgets/popup.dart
+++ b/example/lib/widgets/popup.dart
@@ -5,8 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
-const Duration _tapScaleAnimationDuration = Duration(milliseconds: 100);
+final Duration _animationDuration = Styling.durations.normal;
+final Duration _tapScaleAnimationDuration = Styling.durations.fast;
 
 class Popup extends StatelessWidget {
   final String? title;
@@ -46,7 +46,7 @@ class Popup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/example/lib/widgets/toast.dart
+++ b/example/lib/widgets/toast.dart
@@ -109,7 +109,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 300),
+      duration: Styling.durations.slow,
     );
 
     _fadeAnimation = Tween<double>(
@@ -179,7 +179,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     return Directionality(
       textDirection: TextDirection.ltr,
       child: AnimatedPositioned(
-        duration: const Duration(milliseconds: 200),
+        duration: Styling.durations.normal,
         curve: Curves.easeOut,
         left: 0,
         right: 0,
@@ -204,7 +204,7 @@ class _ToastWidgetState extends State<_ToastWidget>
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       decoration: BoxDecoration(
                         color: bgColor,
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: BorderRadius.circular(Styling.radii.medium),
                         boxShadow: [
                           BoxShadow(
                             blurRadius: 10,

--- a/templates/alert_popup.dart
+++ b/templates/alert_popup.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'styling.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
+final Duration _animationDuration = Styling.durations.normal;
 
 class AlertPopup extends StatelessWidget {
   final Widget? icon;
@@ -54,7 +54,7 @@ class AlertPopup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/templates/button.dart
+++ b/templates/button.dart
@@ -48,7 +48,7 @@ class _ButtonState extends State<Button> with SingleTickerProviderStateMixin {
     super.initState();
 
     _clickAnimationController = AnimationController(
-      duration: const Duration(milliseconds: 100),
+      duration: Styling.durations.fast,
       vsync: this,
     );
 
@@ -186,7 +186,7 @@ class _ButtonState extends State<Button> with SingleTickerProviderStateMixin {
                         : null,
                     borderRadius: widget.variant == ButtonVariant.link
                         ? null
-                        : BorderRadius.circular(12),
+                        : BorderRadius.circular(Styling.radii.medium),
                     boxShadow: _isFocused && !isDisabled
                         ? [
                             BoxShadow(

--- a/templates/confirmation_popup.dart
+++ b/templates/confirmation_popup.dart
@@ -7,7 +7,7 @@ import 'button.dart';
 import 'styling.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
+final Duration _animationDuration = Styling.durations.normal;
 
 class ConfirmationPopup extends StatelessWidget {
   final Widget? icon;
@@ -71,7 +71,7 @@ class ConfirmationPopup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/templates/nav_bar.dart
+++ b/templates/nav_bar.dart
@@ -170,7 +170,7 @@ class _RailItemState extends State<_RailItem> {
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
             decoration: BoxDecoration(
               color: backgroundColor,
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: BorderRadius.circular(Styling.radii.medium),
             ),
             child: Row(
               children: [

--- a/templates/popup.dart
+++ b/templates/popup.dart
@@ -6,8 +6,8 @@ import 'package:flutter/widgets.dart';
 import 'styling.dart';
 
 const double _maxWidth = 560;
-const Duration _animationDuration = Duration(milliseconds: 200);
-const Duration _tapScaleAnimationDuration = Duration(milliseconds: 100);
+final Duration _animationDuration = Styling.durations.normal;
+final Duration _tapScaleAnimationDuration = Styling.durations.fast;
 
 class Popup extends StatelessWidget {
   final String? title;
@@ -47,7 +47,7 @@ class Popup extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: styling.colors.background,
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(Styling.radii.large),
         boxShadow: [
           BoxShadow(
             blurRadius: 24,

--- a/templates/styling.dart
+++ b/templates/styling.dart
@@ -172,6 +172,11 @@ class Styling extends InheritedWidget {
     required super.child,
   });
 
+  // Static - no context needed
+  static RadiusTokens get radii => _radii;
+  static DurationTokens get durations => _durations;
+  static BreakpointTokens get breakpoints => _breakpoints;
+
   static StylingData of(BuildContext context) {
     final Styling? styling =
         context.dependOnInheritedWidgetOfExactType<Styling>();

--- a/templates/styling.dart
+++ b/templates/styling.dart
@@ -1,97 +1,144 @@
 import 'package:flutter/widgets.dart';
 
-// GLOBALS
+// ============================================================================
+// CUSTOMIZE THESE VALUES
+// ============================================================================
+
+// Breakpoints
+const double _desktopBreakpoint = 600;
+
+// Light Theme - Base
+const Color _lightBackground = Color(0xFFFFFFFF);
+const Color _lightBorder = Color(0xFFE4E4E7);
+const Color _lightPrimaryText = Color(0xFF2A2A2A);
+const Color _lightSecondaryText = Color(0xFFACAEAF);
+
+// Light Theme - Button
+const Color _lightButtonPrimary = Color(0xFF18181B);
+const Color _lightButtonPrimaryForeground = Color(0xFFFAFAFA);
+const Color _lightButtonSecondary = Color(0xFFF4F4F5);
+const Color _lightButtonSecondaryForeground = Color(0xFF18181B);
+const Color _lightButtonDestructive = Color(0xFFEF4444);
+const Color _lightButtonDestructiveForeground = Color(0xFFFAFAFA);
+const Color _lightButtonLink = Color(0xFF3B82F6);
+const Color _lightButtonAccent = Color(0xFFF4F4F5);
+
+// Light Theme - Navigation
+const Color _lightNavRailBackground = Color(0xFFFAFAFA);
+const Color _lightNavRailItemBackgroundActive = Color(0xFFFFFFFF);
+const Color _lightNavRailItemBackgroundHover = Color(0xFFF2F2F2);
+const Color _lightNavRailItemText = Color(0xFF2A2A2A);
+const Color _lightNavBottomBarBackground = Color(0xFFFFFFFF);
+const Color _lightNavBottomBarItemActive = Color(0xFF121212);
+const Color _lightNavBottomBarItemInactive = Color(0xFFBBBBBB);
+
+// Light Theme - Toast
+const Color _lightToastSuccess = Color(0xFF52DF82);
+const Color _lightToastError = Color(0xFFFF6D62);
+const Color _lightToastInfo = Color(0xFF529BDF);
+const Color _lightToastWarning = Color(0xFFFFB35A);
+
+// Dark Theme - Base
+const Color _darkBackground = Color(0xFF303030);
+const Color _darkBorder = Color(0xFF27272A);
+const Color _darkPrimaryText = Color(0xFFFAFAFA);
+const Color _darkSecondaryText = Color(0xFFB2B2B2);
+
+// Dark Theme - Button
+const Color _darkButtonPrimary = Color(0xFFFAFAFA);
+const Color _darkButtonPrimaryForeground = Color(0xFF18181B);
+const Color _darkButtonSecondary = Color(0xFF27272A);
+const Color _darkButtonSecondaryForeground = Color(0xFFFAFAFA);
+const Color _darkButtonDestructive = Color(0xFFEF4444);
+const Color _darkButtonDestructiveForeground = Color(0xFFFAFAFA);
+const Color _darkButtonLink = Color(0xFF60A5FA);
+const Color _darkButtonAccent = Color(0xFF27272A);
+
+// Dark Theme - Navigation
+const Color _darkNavRailBackground = Color(0xFF121212);
+const Color _darkNavRailItemBackgroundActive = Color(0xFF2A2A2A);
+const Color _darkNavRailItemBackgroundHover = Color(0xFF080808);
+const Color _darkNavRailItemText = Color(0xFFFAFAFA);
+const Color _darkNavBottomBarBackground = Color(0xFF121212);
+const Color _darkNavBottomBarItemActive = Color(0xFFFAFAFA);
+const Color _darkNavBottomBarItemInactive = Color(0xFF71717A);
+
+// Dark Theme - Toast
+const Color _darkToastSuccess = Color(0xFF52DF82);
+const Color _darkToastError = Color(0xFFFF6D62);
+const Color _darkToastInfo = Color(0xFF529BDF);
+const Color _darkToastWarning = Color(0xFFFFB35A);
+
+// ============================================================================
+// INTERNAL - NO NEED TO EDIT BELOW
+// ============================================================================
+
 final Breakpoints _breakpoints = Breakpoints(
-  desktop: 600,
+  desktop: _desktopBreakpoint,
 );
 
-// LIGHT
-const Color _backgroundLight = Color(0xFFFFFFFF);
-const Color _borderLight = Color(0xFFE4E4E7);
-const Color _primaryTextLight = Color(0xff2A2A2A);
-const Color _secondaryTextLight = Color(0xffACAEAF);
-
-final ButtonColors _buttonColorsLight = ButtonColors(
-  primary: const Color(0xFF18181B),
-  primaryForeground: const Color(0xFFFAFAFA),
-  secondary: const Color(0xFFF4F4F5),
-  secondaryForeground: const Color(0xFF18181B),
-  destructive: const Color(0xFFEF4444),
-  destructiveForeground: const Color(0xFFFAFAFA),
-  link: const Color(0xFF3B82F6),
-  accent: const Color(0xFFF4F4F5),
+final AppColors _colorsLight = AppColors(
+  background: _lightBackground,
+  border: _lightBorder,
+  primaryText: _lightPrimaryText,
+  secondaryText: _lightSecondaryText,
+  button: ButtonColors(
+    primary: _lightButtonPrimary,
+    primaryForeground: _lightButtonPrimaryForeground,
+    secondary: _lightButtonSecondary,
+    secondaryForeground: _lightButtonSecondaryForeground,
+    destructive: _lightButtonDestructive,
+    destructiveForeground: _lightButtonDestructiveForeground,
+    link: _lightButtonLink,
+    accent: _lightButtonAccent,
+  ),
+  navigation: NavigationColors(
+    railBackground: _lightNavRailBackground,
+    railItemBackgroundActive: _lightNavRailItemBackgroundActive,
+    railItemBackgroundHover: _lightNavRailItemBackgroundHover,
+    railItemText: _lightNavRailItemText,
+    bottomBarBackground: _lightNavBottomBarBackground,
+    bottomBarItemActive: _lightNavBottomBarItemActive,
+    bottomBarItemInactive: _lightNavBottomBarItemInactive,
+  ),
+  toast: ToastColors(
+    success: _lightToastSuccess,
+    error: _lightToastError,
+    info: _lightToastInfo,
+    warning: _lightToastWarning,
+  ),
 );
 
-final NavigationColors _navigationColorsLight = NavigationColors(
-  railBackground: const Color(0xFFFAFAFA),
-  railItemBackgroundActive: const Color(0xFFFFFFFF),
-  railItemBackgroundHover: const Color(0xFFF2F2F2),
-  railItemText: const Color(0xFF2A2A2A),
-  bottomBarBackground: const Color(0xFFFFFFFF),
-  bottomBarItemActive: const Color(0xFF121212),
-  bottomBarItemInactive: const Color(0xFFBBBBBB),
-);
-
-const ToastColors _toastColorsLight = ToastColors(
-  success: Color(0xFF52DF82),
-  error: Color(0xFFFF6D62),
-  info: Color(0xFF529BDF),
-  warning: Color(0xFFFFB35A),
-);
-
-// DARK
-const Color _backgroundDark = Color(0xFF303030);
-const Color _borderDark = Color(0xFF27272A);
-const Color _primaryTextDark = Color(0xffFAFAFA);
-const Color _secondaryTextDark = Color(0xffB2B2B2);
-
-final ButtonColors _buttonColorsDark = ButtonColors(
-  primary: Color(0xFFFAFAFA),
-  primaryForeground: Color(0xFF18181B),
-  secondary: Color(0xFF27272A),
-  secondaryForeground: Color(0xFFFAFAFA),
-  destructive: Color(0xFFEF4444),
-  destructiveForeground: Color(0xFFFAFAFA),
-  link: Color(0xFF60A5FA),
-  accent: Color(0xFF27272A),
-);
-
-final NavigationColors _navigationColorsDark = NavigationColors(
-  railBackground: Color(0xFF121212),
-  railItemBackgroundActive: Color(0xFF2A2A2A),
-  railItemBackgroundHover: Color(0xFF080808),
-  railItemText: Color(0xFFFAFAFA),
-  bottomBarBackground: Color(0xFF121212),
-  bottomBarItemActive: Color(0xFFFAFAFA),
-  bottomBarItemInactive: Color(0xFF71717A),
-);
-
-const ToastColors _toastColorsDark = ToastColors(
-  success: Color(0xFF52DF82),
-  error: Color(0xFFFF6D62),
-  info: Color(0xFF529BDF),
-  warning: Color(0xFFFFB35A),
-);
-
-// NO TOUCHING
-final AppColors _appColorsLight = AppColors(
-  background: _backgroundLight,
-  border: _borderLight,
-  primaryText: _primaryTextLight,
-  secondaryText: _secondaryTextLight,
-  navigation: _navigationColorsLight,
-  button: _buttonColorsLight,
-  toast: _toastColorsLight,
-);
-
-final AppColors _appColorsDark = AppColors(
-  background: _backgroundDark,
-  border: _borderDark,
-  primaryText: _primaryTextDark,
-  secondaryText: _secondaryTextDark,
-  button: _buttonColorsDark,
-  navigation: _navigationColorsDark,
-  toast: _toastColorsDark,
+final AppColors _colorsDark = AppColors(
+  background: _darkBackground,
+  border: _darkBorder,
+  primaryText: _darkPrimaryText,
+  secondaryText: _darkSecondaryText,
+  button: ButtonColors(
+    primary: _darkButtonPrimary,
+    primaryForeground: _darkButtonPrimaryForeground,
+    secondary: _darkButtonSecondary,
+    secondaryForeground: _darkButtonSecondaryForeground,
+    destructive: _darkButtonDestructive,
+    destructiveForeground: _darkButtonDestructiveForeground,
+    link: _darkButtonLink,
+    accent: _darkButtonAccent,
+  ),
+  navigation: NavigationColors(
+    railBackground: _darkNavRailBackground,
+    railItemBackgroundActive: _darkNavRailItemBackgroundActive,
+    railItemBackgroundHover: _darkNavRailItemBackgroundHover,
+    railItemText: _darkNavRailItemText,
+    bottomBarBackground: _darkNavBottomBarBackground,
+    bottomBarItemActive: _darkNavBottomBarItemActive,
+    bottomBarItemInactive: _darkNavBottomBarItemInactive,
+  ),
+  toast: ToastColors(
+    success: _darkToastSuccess,
+    error: _darkToastError,
+    info: _darkToastInfo,
+    warning: _darkToastWarning,
+  ),
 );
 
 class Styling extends InheritedWidget {
@@ -104,8 +151,8 @@ class Styling extends InheritedWidget {
   });
 
   static StylingData of(BuildContext context) {
-    final Styling? styling = context
-        .dependOnInheritedWidgetOfExactType<Styling>();
+    final Styling? styling =
+        context.dependOnInheritedWidgetOfExactType<Styling>();
 
     assert(
       styling != null,
@@ -116,7 +163,7 @@ class Styling extends InheritedWidget {
 
     return StylingData(
       isDark: isDark,
-      colors: isDark ? _appColorsDark : _appColorsLight,
+      colors: isDark ? _colorsDark : _colorsLight,
       breakpoints: _breakpoints,
     );
   }
@@ -132,7 +179,7 @@ class StylingData {
   final AppColors colors;
   final Breakpoints breakpoints;
 
-  StylingData({
+  const StylingData({
     required this.isDark,
     required this.colors,
     required this.breakpoints,
@@ -208,8 +255,6 @@ class AppColors {
   final Color border;
   final Color primaryText;
   final Color secondaryText;
-
-  // Component colors
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;

--- a/templates/styling.dart
+++ b/templates/styling.dart
@@ -7,6 +7,16 @@ import 'package:flutter/widgets.dart';
 // Breakpoints
 const double _desktopBreakpoint = 600;
 
+// Radii
+const double _radiusSmall = 8;
+const double _radiusMedium = 12;
+const double _radiusLarge = 24;
+
+// Durations
+const Duration _durationFast = Duration(milliseconds: 100);
+const Duration _durationNormal = Duration(milliseconds: 200);
+const Duration _durationSlow = Duration(milliseconds: 300);
+
 // Light Theme - Base
 const Color _lightBackground = Color(0xFFFFFFFF);
 const Color _lightBorder = Color(0xFFE4E4E7);
@@ -73,11 +83,23 @@ const Color _darkToastWarning = Color(0xFFFFB35A);
 // INTERNAL - NO NEED TO EDIT BELOW
 // ============================================================================
 
-final Breakpoints _breakpoints = Breakpoints(
+final BreakpointTokens _breakpoints = BreakpointTokens(
   desktop: _desktopBreakpoint,
 );
 
-final AppColors _colorsLight = AppColors(
+final RadiusTokens _radii = RadiusTokens(
+  small: _radiusSmall,
+  medium: _radiusMedium,
+  large: _radiusLarge,
+);
+
+final DurationTokens _durations = DurationTokens(
+  fast: _durationFast,
+  normal: _durationNormal,
+  slow: _durationSlow,
+);
+
+final ColorTokens _colorsLight = ColorTokens(
   background: _lightBackground,
   border: _lightBorder,
   primaryText: _lightPrimaryText,
@@ -109,7 +131,7 @@ final AppColors _colorsLight = AppColors(
   ),
 );
 
-final AppColors _colorsDark = AppColors(
+final ColorTokens _colorsDark = ColorTokens(
   background: _darkBackground,
   border: _darkBorder,
   primaryText: _darkPrimaryText,
@@ -164,6 +186,8 @@ class Styling extends InheritedWidget {
     return StylingData(
       isDark: isDark,
       colors: isDark ? _colorsDark : _colorsLight,
+      radii: _radii,
+      durations: _durations,
       breakpoints: _breakpoints,
     );
   }
@@ -176,21 +200,49 @@ class Styling extends InheritedWidget {
 
 class StylingData {
   final bool isDark;
-  final AppColors colors;
-  final Breakpoints breakpoints;
+  final ColorTokens colors;
+  final RadiusTokens radii;
+  final DurationTokens durations;
+  final BreakpointTokens breakpoints;
 
   const StylingData({
     required this.isDark,
     required this.colors,
+    required this.radii,
+    required this.durations,
     required this.breakpoints,
   });
 }
 
-class Breakpoints {
+class BreakpointTokens {
   final double desktop;
 
-  const Breakpoints({
+  const BreakpointTokens({
     required this.desktop,
+  });
+}
+
+class RadiusTokens {
+  final double small;
+  final double medium;
+  final double large;
+
+  const RadiusTokens({
+    required this.small,
+    required this.medium,
+    required this.large,
+  });
+}
+
+class DurationTokens {
+  final Duration fast;
+  final Duration normal;
+  final Duration slow;
+
+  const DurationTokens({
+    required this.fast,
+    required this.normal,
+    required this.slow,
   });
 }
 
@@ -250,7 +302,7 @@ class ToastColors {
   });
 }
 
-class AppColors {
+class ColorTokens {
   final Color background;
   final Color border;
   final Color primaryText;
@@ -259,7 +311,7 @@ class AppColors {
   final NavigationColors navigation;
   final ToastColors toast;
 
-  const AppColors({
+  const ColorTokens({
     required this.background,
     required this.border,
     required this.primaryText,

--- a/templates/toast.dart
+++ b/templates/toast.dart
@@ -110,7 +110,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 300),
+      duration: Styling.durations.slow,
     );
 
     _fadeAnimation = Tween<double>(
@@ -180,7 +180,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     return Directionality(
       textDirection: TextDirection.ltr,
       child: AnimatedPositioned(
-        duration: const Duration(milliseconds: 200),
+        duration: Styling.durations.normal,
         curve: Curves.easeOut,
         left: 0,
         right: 0,
@@ -205,7 +205,7 @@ class _ToastWidgetState extends State<_ToastWidget>
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       decoration: BoxDecoration(
                         color: bgColor,
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: BorderRadius.circular(Styling.radii.medium),
                         boxShadow: [
                           BoxShadow(
                             blurRadius: 10,


### PR DESCRIPTION
## Summary
Restructures the styling system for better to make it easily customisable, and a bit of consistency.

## Changes
- Restructured styling.dart (customizable values at top)
- Renamed to XxxTokens convention (`AppColors` → `ColorTokens`, `Breakpoints` → `BreakpointTokens`)
- Added `RadiusTokens` (small, medium, large) and `DurationTokens` (fast, normal, slow)
- Added static getters for tokens that don't need context
- Updated all widgets to use tokens

## Breaking Changes
- `AppColors` → `ColorTokens`
- `Breakpoints` → `BreakpointTokens`
- `Styling.of(context).breakpoints` → `Styling.breakpoints` (static)
- `Styling.of(context).radii` → `Styling.radii` (static)
- `Styling.of(context).durations` → `Styling.durations` (static)