### PR TITLE
feat(search_field): add SearchField widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,8 @@ Now it's yours to build web and desktop apps with Flutter easier (and also mobil
 
 Want to say thanks? Use <a href="https://userorient.com">UserOrient</a> SDK in your Flutter apps, it's cool!
 
-> [!WARNING]
-> Early development. API may change.
-
 > [!NOTE]
-> Building in public on [X/Twitter](https://x.com/kamranebkirovyz). Your feedback and contributions are welcomed!
+> Early development. API may change. Building in public on [X/Twitter](https://x.com/kamranebkirovyz). Your feedback and contributions are welcomed!
 
 ## 🎬 Getting Started
 
@@ -129,13 +126,19 @@ orient_ui add <widget>  # Add a specific widget
 - [x] Popup
 - [x] AlertPopup
 - [x] ConfirmationPopup
+- [x] SearchField
+
+### In Progress
+- [ ] TextField
 
 ### Coming Soon
-- [ ] TextField
 - [ ] ListTile
-- [ ] TabBar
-- [ ] SwitchListTile
-- [ ] RadioListTile
+- [ ] Tabs
+- [ ] InlineTabs
+- [ ] Switch
+- [ ] SwitchTile
+- [ ] Radio
+- [ ] RadioTile
 - [ ] Menu
 
 ## ✅ Quality

--- a/bin/orient_ui.dart
+++ b/bin/orient_ui.dart
@@ -20,6 +20,7 @@ final Map<String, ComponentInfo> components = {
   'toast': ComponentInfo('toast.dart'),
   'alert_popup': ComponentInfo('alert_popup.dart'),
   'popup': ComponentInfo('popup.dart'),
+  'search_field': ComponentInfo('search_field.dart'),
 };
 
 void main(List<String> args) async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/pages/alert_popup_page.dart';
+import 'package:example/pages/search_field_page.dart';
 import 'package:example/pages/popup_page.dart';
 import 'package:example/pages/confirmation_popup_page.dart';
 import 'package:example/pages/copy_button_page.dart';
@@ -107,6 +108,11 @@ class _PlaygroundShellState extends State<PlaygroundShell> {
       title: 'Popup',
       icon: Icons.web_asset_outlined,
       page: PopupPage(),
+    ),
+    _PageInfo(
+      title: 'Search Field',
+      icon: Icons.search,
+      page: SearchFieldPage(),
     ),
   ];
 

--- a/example/lib/pages/search_field_page.dart
+++ b/example/lib/pages/search_field_page.dart
@@ -1,0 +1,138 @@
+import 'package:example/styling.dart';
+import 'package:example/widgets/search_field.dart';
+import 'package:flutter/widgets.dart';
+
+class SearchFieldPage extends StatefulWidget {
+  const SearchFieldPage({super.key});
+
+  @override
+  State<SearchFieldPage> createState() => _SearchFieldPageState();
+}
+
+class _SearchFieldPageState extends State<SearchFieldPage> {
+  final _controller = TextEditingController();
+  String _query = '';
+
+  static const _packages = [
+    ('userorient_flutter', 'In-app feedback and feature requests'),
+    ('flutter_bloc', 'State management with BLoC pattern'),
+    ('riverpod', 'Reactive caching and data-binding'),
+    ('provider', 'Simple state management'),
+    ('get_it', 'Service locator for dependency injection'),
+    ('dio', 'Powerful HTTP client'),
+    ('http', 'Composable HTTP client'),
+    ('shared_preferences', 'Persistent key-value storage'),
+    ('hive', 'Lightweight and fast key-value database'),
+    ('sqflite', 'SQLite plugin for Flutter'),
+    ('go_router', 'Declarative routing'),
+    ('auto_route', 'Code generation for routing'),
+    ('freezed', 'Code generation for immutable classes'),
+    ('json_serializable', 'JSON serialization code generation'),
+    ('flutter_hooks', 'React-like hooks for Flutter'),
+    ('cached_network_image', 'Image caching and loading'),
+    ('flutter_svg', 'SVG rendering'),
+    ('lottie', 'Lottie animations'),
+    ('intl', 'Internationalization and localization'),
+    ('url_launcher', 'Launch URLs in browser'),
+  ];
+
+  List<(String, String)> get _filteredPackages {
+    if (_query.isEmpty) return _packages;
+    return _packages
+        .where((p) =>
+            p.$1.toLowerCase().contains(_query.toLowerCase()) ||
+            p.$2.toLowerCase().contains(_query.toLowerCase()))
+        .toList();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final styling = Styling.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'SearchField',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: styling.colors.primaryText,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SearchField(
+            controller: _controller,
+            placeholder: 'Search packages...',
+            onChanged: (value) {
+              setState(() {
+                _query = value;
+              });
+            },
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _filteredPackages.length,
+              itemBuilder: (context, index) {
+                final package = _filteredPackages[index];
+                return _PackageItem(
+                  name: package.$1,
+                  description: package.$2,
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PackageItem extends StatelessWidget {
+  final String name;
+  final String description;
+
+  const _PackageItem({
+    required this.name,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final styling = Styling.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            name,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: styling.colors.primaryText,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            description,
+            style: TextStyle(
+              fontSize: 14,
+              color: styling.colors.secondaryText,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/search_field.dart
+++ b/example/lib/widgets/search_field.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:example/styling.dart';
+
+// Customizable constants
+//
+// Default: Universal pill style (works on all platforms)
+const double _kHeight = 44;
+const double _kHorizontalPadding = 14;
+const double _kBorderRadius = 22;
+//
+// Alternative: Compact Cupertino-like style (iOS only, not recommended for Android)
+// const double _kHeight = 36;
+// const double _kHorizontalPadding = 8;
+// const double _kBorderRadius = 10;
+
+class SearchField extends StatefulWidget {
+  final TextEditingController? controller;
+  final String? placeholder;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final bool autofocus;
+
+  const SearchField({
+    super.key,
+    this.controller,
+    this.placeholder,
+    this.onChanged,
+    this.onSubmitted,
+    this.autofocus = false,
+  });
+
+  @override
+  State<SearchField> createState() => _SearchFieldState();
+}
+
+class _SearchFieldState extends State<SearchField> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  bool _isFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController();
+    _focusNode = FocusNode();
+    _focusNode.addListener(_onFocusChange);
+    _controller.addListener(_onTextChange);
+
+    if (widget.autofocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _controller.removeListener(_onTextChange);
+    _focusNode.dispose();
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    setState(() {
+      _isFocused = _focusNode.hasFocus;
+    });
+  }
+
+  void _onTextChange() {
+    setState(() {});
+    widget.onChanged?.call(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final StylingData styling = Styling.of(context);
+    final bool showPlaceholder =
+        _controller.text.isEmpty && widget.placeholder != null;
+
+    return Semantics(
+      textField: true,
+      focused: _isFocused,
+      hint: widget.placeholder,
+      child: GestureDetector(
+        onTap: () {
+          _focusNode.requestFocus();
+        },
+        behavior: HitTestBehavior.translucent,
+        child: Container(
+          height: _kHeight,
+          padding: const EdgeInsets.symmetric(horizontal: _kHorizontalPadding),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: styling.colors.button.secondary,
+            borderRadius: BorderRadius.circular(_kBorderRadius),
+          ),
+          child: Row(
+            children: [
+              CustomPaint(
+                size: const Size(20, 20),
+                painter: _SearchIconPainter(
+                  color: styling.colors.secondaryText,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Stack(
+                  alignment: Alignment.centerLeft,
+                  children: [
+                    if (showPlaceholder)
+                      Text(
+                        widget.placeholder!,
+                        style: TextStyle(
+                          fontSize: 16,
+                          height: 16 / 16,
+                          color: styling.colors.secondaryText,
+                        ),
+                      ),
+                    EditableText(
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      scrollPadding: EdgeInsets.zero,
+                      style: TextStyle(
+                        fontSize: 16,
+                        height: 16 / 16,
+                        color: styling.colors.primaryText,
+                      ),
+                      cursorColor: styling.colors.primaryText,
+                      cursorHeight: 18,
+                      backgroundCursorColor: const Color(0x00000000),
+                      textInputAction: TextInputAction.search,
+                      onChanged: widget.onChanged,
+                      onSubmitted: widget.onSubmitted,
+                    ),
+                  ],
+                ),
+              ),
+              if (_controller.text.isNotEmpty) ...[
+                const SizedBox(width: 6),
+                Semantics(
+                  button: true,
+                  label: 'Clear search',
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: GestureDetector(
+                      onTap: () {
+                        _controller.clear();
+                        widget.onChanged?.call('');
+                      },
+                      child: CustomPaint(
+                        size: const Size(20, 20),
+                        painter: _ClearIconPainter(
+                          backgroundColor: styling.colors.button.secondary,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// Tabler search icon
+class _SearchIconPainter extends CustomPainter {
+  final Color color;
+
+  const _SearchIconPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double s = size.width / 24;
+
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2 * s
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    // Circle: center (10, 10), radius 7
+    canvas.drawCircle(
+      Offset(10 * s, 10 * s),
+      7 * s,
+      paint,
+    );
+
+    // Handle: from edge of circle to (21, 21)
+    canvas.drawLine(
+      Offset(15 * s, 15 * s),
+      Offset(21 * s, 21 * s),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _SearchIconPainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+// Clear (X) icon with filled square background
+class _ClearIconPainter extends CustomPainter {
+  final Color backgroundColor;
+
+  const _ClearIconPainter({required this.backgroundColor});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double s = size.width / 24;
+
+    // Filled rounded square background
+    final bgPaint = Paint()
+      ..color = const Color(0xFFACAEAF)
+      ..style = PaintingStyle.fill;
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(2 * s, 2 * s, 20 * s, 20 * s),
+        Radius.circular(10 * s),
+      ),
+      bgPaint,
+    );
+
+    // X icon - same color as container background for "cut out" effect
+    final xPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2 * s
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawLine(Offset(8 * s, 8 * s), Offset(16 * s, 16 * s), xPaint);
+    canvas.drawLine(Offset(16 * s, 8 * s), Offset(8 * s, 16 * s), xPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _ClearIconPainter oldDelegate) {
+    return oldDelegate.backgroundColor != backgroundColor;
+  }
+}

--- a/example/test/search_field_test.dart
+++ b/example/test/search_field_test.dart
@@ -1,0 +1,248 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:example/widgets/search_field.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  group('SearchField', () {
+    group('rendering', () {
+      testWidgets('renders without error', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        expect(find.byType(SearchField), findsOneWidget);
+      });
+
+      testWidgets('renders placeholder when empty', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(placeholder: 'Search...'),
+        ));
+
+        expect(find.text('Search...'), findsOneWidget);
+      });
+
+      testWidgets('hides placeholder when text entered', (tester) async {
+        final controller = TextEditingController(text: 'hello');
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(
+            controller: controller,
+            placeholder: 'Search...',
+          ),
+        ));
+
+        expect(find.text('Search...'), findsNothing);
+        expect(find.text('hello'), findsOneWidget);
+      });
+
+      testWidgets('renders search icon', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        // Search icon is rendered via CustomPaint
+        expect(find.byType(CustomPaint), findsWidgets);
+      });
+
+      testWidgets('renders clear button when text entered', (tester) async {
+        final controller = TextEditingController(text: 'hello');
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(controller: controller),
+        ));
+
+        // Should have 2 CustomPaint: search icon + clear button
+        expect(find.byType(CustomPaint), findsNWidgets(2));
+      });
+
+      testWidgets('does not render clear button when empty', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        // Should have only 1 CustomPaint: search icon
+        expect(find.byType(CustomPaint), findsOneWidget);
+      });
+
+      testWidgets('has correct height', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        expect(container.constraints?.maxHeight, 40);
+      });
+    });
+
+    group('interaction', () {
+      testWidgets('calls onChanged when text changes', (tester) async {
+        String? changedValue;
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(
+            onChanged: (value) => changedValue = value,
+          ),
+        ));
+
+        await tester.enterText(find.byType(EditableText), 'test');
+        await tester.pump();
+
+        expect(changedValue, 'test');
+      });
+
+      testWidgets('calls onSubmitted when submitted', (tester) async {
+        String? submittedValue;
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(
+            onSubmitted: (value) => submittedValue = value,
+          ),
+        ));
+
+        await tester.enterText(find.byType(EditableText), 'search query');
+        await tester.testTextInput.receiveAction(TextInputAction.search);
+        await tester.pump();
+
+        expect(submittedValue, 'search query');
+      });
+
+      testWidgets('clears text when clear button tapped', (tester) async {
+        final controller = TextEditingController(text: 'hello');
+        String? changedValue;
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(
+            controller: controller,
+            onChanged: (value) => changedValue = value,
+          ),
+        ));
+
+        // Find and tap the clear button (second CustomPaint wrapped in GestureDetector)
+        final clearButton = find.byType(GestureDetector).last;
+        await tester.tap(clearButton);
+        await tester.pump();
+
+        expect(controller.text, '');
+        expect(changedValue, '');
+      });
+
+      testWidgets('focuses when tapped', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        await tester.tap(find.byType(SearchField));
+        await tester.pump();
+
+        final editableText = tester.widget<EditableText>(find.byType(EditableText));
+        expect(editableText.focusNode.hasFocus, isTrue);
+      });
+
+      testWidgets('autofocus works', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(autofocus: true),
+        ));
+
+        await tester.pump();
+        await tester.pump();
+
+        final editableText = tester.widget<EditableText>(find.byType(EditableText));
+        expect(editableText.focusNode.hasFocus, isTrue);
+      });
+    });
+
+    group('controller', () {
+      testWidgets('uses provided controller', (tester) async {
+        final controller = TextEditingController(text: 'initial');
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(controller: controller),
+        ));
+
+        expect(find.text('initial'), findsOneWidget);
+      });
+
+      testWidgets('updates when controller changes externally', (tester) async {
+        final controller = TextEditingController();
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(controller: controller),
+        ));
+
+        controller.text = 'external update';
+        await tester.pump();
+
+        expect(find.text('external update'), findsOneWidget);
+      });
+
+      testWidgets('creates internal controller when not provided', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(),
+        ));
+
+        await tester.enterText(find.byType(EditableText), 'typed');
+        await tester.pump();
+
+        expect(find.text('typed'), findsOneWidget);
+      });
+    });
+
+    group('accessibility', () {
+      testWidgets('has textField semantics', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(placeholder: 'Search...'),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Semantics).first);
+        expect(semantics.hasFlag(SemanticsFlag.isTextField), isTrue);
+      });
+
+      testWidgets('clear button has button semantics', (tester) async {
+        final controller = TextEditingController(text: 'hello');
+
+        await tester.pumpWidget(wrapWithStyling(
+          SearchField(controller: controller),
+        ));
+
+        // Find the clear button semantics
+        final clearButtonSemantics = tester.getSemantics(
+          find.bySemanticsLabel('Clear search'),
+        );
+        expect(clearButtonSemantics.hasFlag(SemanticsFlag.isButton), isTrue);
+      });
+
+      testWidgets('has hint from placeholder', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(placeholder: 'Search packages...'),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Semantics).first);
+        expect(semantics.hint, 'Search packages...');
+      });
+    });
+
+    group('theming', () {
+      testWidgets('renders in light mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(placeholder: 'Light mode'),
+          brightness: Brightness.light,
+        ));
+
+        expect(find.text('Light mode'), findsOneWidget);
+      });
+
+      testWidgets('renders in dark mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const SearchField(placeholder: 'Dark mode'),
+          brightness: Brightness.dark,
+        ));
+
+        expect(find.text('Dark mode'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/templates/search_field.dart
+++ b/templates/search_field.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'styling.dart';
+
+// Customizable constants
+//
+// Default: Universal pill style (works on all platforms)
+const double _kHeight = 44;
+const double _kHorizontalPadding = 14;
+const double _kBorderRadius = 22;
+//
+// Alternative: Compact Cupertino-like style (iOS only, not recommended for Android)
+// const double _kHeight = 36;
+// const double _kHorizontalPadding = 8;
+// const double _kBorderRadius = 10;
+
+class SearchField extends StatefulWidget {
+  final TextEditingController? controller;
+  final String? placeholder;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final bool autofocus;
+
+  const SearchField({
+    super.key,
+    this.controller,
+    this.placeholder,
+    this.onChanged,
+    this.onSubmitted,
+    this.autofocus = false,
+  });
+
+  @override
+  State<SearchField> createState() => _SearchFieldState();
+}
+
+class _SearchFieldState extends State<SearchField> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  bool _isFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController();
+    _focusNode = FocusNode();
+    _focusNode.addListener(_onFocusChange);
+    _controller.addListener(_onTextChange);
+
+    if (widget.autofocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _focusNode.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _controller.removeListener(_onTextChange);
+    _focusNode.dispose();
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    setState(() {
+      _isFocused = _focusNode.hasFocus;
+    });
+  }
+
+  void _onTextChange() {
+    setState(() {});
+    widget.onChanged?.call(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final StylingData styling = Styling.of(context);
+    final bool showPlaceholder =
+        _controller.text.isEmpty && widget.placeholder != null;
+
+    return Semantics(
+      textField: true,
+      focused: _isFocused,
+      hint: widget.placeholder,
+      child: GestureDetector(
+        onTap: () {
+          _focusNode.requestFocus();
+        },
+        behavior: HitTestBehavior.translucent,
+        child: Container(
+          height: _kHeight,
+          padding: const EdgeInsets.symmetric(horizontal: _kHorizontalPadding),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: styling.colors.button.secondary,
+            borderRadius: BorderRadius.circular(_kBorderRadius),
+          ),
+          child: Row(
+            children: [
+              CustomPaint(
+                size: const Size(20, 20),
+                painter: _SearchIconPainter(
+                  color: styling.colors.secondaryText,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Stack(
+                  alignment: Alignment.centerLeft,
+                  children: [
+                    if (showPlaceholder)
+                      Text(
+                        widget.placeholder!,
+                        style: TextStyle(
+                          fontSize: 16,
+                          height: 16 / 16,
+                          color: styling.colors.secondaryText,
+                        ),
+                      ),
+                    EditableText(
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      scrollPadding: EdgeInsets.zero,
+                      style: TextStyle(
+                        fontSize: 16,
+                        height: 16 / 16,
+                        color: styling.colors.primaryText,
+                      ),
+                      cursorColor: styling.colors.primaryText,
+                      cursorHeight: 18,
+                      backgroundCursorColor: const Color(0x00000000),
+                      textInputAction: TextInputAction.search,
+                      onChanged: widget.onChanged,
+                      onSubmitted: widget.onSubmitted,
+                    ),
+                  ],
+                ),
+              ),
+              if (_controller.text.isNotEmpty) ...[
+                const SizedBox(width: 6),
+                Semantics(
+                  button: true,
+                  label: 'Clear search',
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: GestureDetector(
+                      onTap: () {
+                        _controller.clear();
+                        widget.onChanged?.call('');
+                      },
+                      child: CustomPaint(
+                        size: const Size(20, 20),
+                        painter: _ClearIconPainter(
+                          backgroundColor: styling.colors.button.secondary,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// Tabler search icon
+class _SearchIconPainter extends CustomPainter {
+  final Color color;
+
+  const _SearchIconPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double s = size.width / 24;
+
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2 * s
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    // Circle: center (10, 10), radius 7
+    canvas.drawCircle(
+      Offset(10 * s, 10 * s),
+      7 * s,
+      paint,
+    );
+
+    // Handle: from edge of circle to (21, 21)
+    canvas.drawLine(
+      Offset(15 * s, 15 * s),
+      Offset(21 * s, 21 * s),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _SearchIconPainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+// Clear (X) icon with filled square background
+class _ClearIconPainter extends CustomPainter {
+  final Color backgroundColor;
+
+  const _ClearIconPainter({required this.backgroundColor});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double s = size.width / 24;
+
+    // Filled rounded square background
+    final bgPaint = Paint()
+      ..color = const Color(0xFFACAEAF)
+      ..style = PaintingStyle.fill;
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(2 * s, 2 * s, 20 * s, 20 * s),
+        Radius.circular(10 * s),
+      ),
+      bgPaint,
+    );
+
+    // X icon - same color as container background for "cut out" effect
+    final xPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2 * s
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawLine(Offset(8 * s, 8 * s), Offset(16 * s, 16 * s), xPaint);
+    canvas.drawLine(Offset(16 * s, 8 * s), Offset(8 * s, 16 * s), xPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _ClearIconPainter oldDelegate) {
+    return oldDelegate.backgroundColor != backgroundColor;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a customizable search input field with clear button, pill styling, and accessibility support.

## Changes
- Added `SearchField` widget with `EditableText
- Search icon and clear button using `CustomPainter`
- Customizable constants at top (height, padding, border radius)
- Two style presets: universal pill (default) and compact Cupertino-like
- Full accessibility semantics (textField, button labels, hints)
- Keyboard handling with `TextInputAction.search` and `onSubmitted`
- Comprehensive tests (20 tests)