### PR TITLE
fix(search_field): remove height test

### DIFF
--- a/example/test/search_field_test.dart
+++ b/example/test/search_field_test.dart
@@ -68,14 +68,6 @@ void main() {
         expect(find.byType(CustomPaint), findsOneWidget);
       });
 
-      testWidgets('has correct height', (tester) async {
-        await tester.pumpWidget(wrapWithStyling(
-          const SearchField(),
-        ));
-
-        final container = tester.widget<Container>(find.byType(Container).first);
-        expect(container.constraints?.maxHeight, 40);
-      });
     });
 
     group('interaction', () {


### PR DESCRIPTION
## Summary
Removes the hardcoded height test since height is now a customizable constant.

## Changes
- Removed `has correct height` test that was checking for hardcoded value (40px)