### PR TITLE
feat(toggle): add toggle widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:example/pages/alert_popup_page.dart';
 import 'package:example/pages/search_field_page.dart';
+import 'package:example/pages/toggle_page.dart';
 import 'package:example/pages/popup_page.dart';
 import 'package:example/pages/confirmation_popup_page.dart';
 import 'package:example/pages/copy_button_page.dart';
@@ -113,6 +114,11 @@ class _PlaygroundShellState extends State<PlaygroundShell> {
       title: 'Search Field',
       icon: Icons.search,
       page: SearchFieldPage(),
+    ),
+    _PageInfo(
+      title: 'Toggle',
+      icon: Icons.toggle_on_outlined,
+      page: TogglePage(),
     ),
   ];
 

--- a/example/lib/pages/toggle_page.dart
+++ b/example/lib/pages/toggle_page.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:example/widgets/toggle.dart';
+
+class TogglePage extends StatefulWidget {
+  const TogglePage({super.key});
+
+  @override
+  State<TogglePage> createState() => _TogglePageState();
+}
+
+class _TogglePageState extends State<TogglePage> {
+  bool _default1 = false;
+  bool _default2 = true;
+  bool _small1 = false;
+  bool _small2 = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSection(
+            title: 'Default',
+            child: Row(
+              children: [
+                Toggle(
+                  value: _default1,
+                  onChanged: (v) => setState(() => _default1 = v),
+                ),
+                const SizedBox(width: 16),
+                Toggle(
+                  value: _default2,
+                  onChanged: (v) => setState(() => _default2 = v),
+                ),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'Small',
+            child: Row(
+              children: [
+                Toggle.small(
+                  value: _small1,
+                  onChanged: (v) => setState(() => _small1 = v),
+                ),
+                const SizedBox(width: 16),
+                Toggle.small(
+                  value: _small2,
+                  onChanged: (v) => setState(() => _small2 = v),
+                ),
+              ],
+            ),
+          ),
+          _buildSection(
+            title: 'Disabled',
+            child: Row(
+              children: [
+                const Toggle(value: false),
+                const SizedBox(width: 16),
+                const Toggle(value: true),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection({required String title, required Widget child}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF71717A),
+            ),
+          ),
+          const SizedBox(height: 12),
+          child,
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/styling.dart
+++ b/example/lib/styling.dart
@@ -22,6 +22,8 @@ const Color _lightBackground = Color(0xFFFFFFFF);
 const Color _lightBorder = Color(0xFFE4E4E7);
 const Color _lightPrimaryText = Color(0xFF2A2A2A);
 const Color _lightSecondaryText = Color(0xFFACAEAF);
+const Color _lightAccent = Color(0xFF18181B);
+const Color _lightAccentForeground = Color(0xFFFAFAFA);
 
 // Light Theme - Button
 const Color _lightButtonPrimary = Color(0xFF18181B);
@@ -53,6 +55,8 @@ const Color _darkBackground = Color(0xFF303030);
 const Color _darkBorder = Color(0xFF27272A);
 const Color _darkPrimaryText = Color(0xFFFAFAFA);
 const Color _darkSecondaryText = Color(0xFFB2B2B2);
+const Color _darkAccent = Color(0xFFFAFAFA);
+const Color _darkAccentForeground = Color(0xFF18181B);
 
 // Dark Theme - Button
 const Color _darkButtonPrimary = Color(0xFFFAFAFA);
@@ -104,6 +108,8 @@ final ColorTokens _colorsLight = ColorTokens(
   border: _lightBorder,
   primaryText: _lightPrimaryText,
   secondaryText: _lightSecondaryText,
+  accent: _lightAccent,
+  accentForeground: _lightAccentForeground,
   button: ButtonColors(
     primary: _lightButtonPrimary,
     primaryForeground: _lightButtonPrimaryForeground,
@@ -136,6 +142,8 @@ final ColorTokens _colorsDark = ColorTokens(
   border: _darkBorder,
   primaryText: _darkPrimaryText,
   secondaryText: _darkSecondaryText,
+  accent: _darkAccent,
+  accentForeground: _darkAccentForeground,
   button: ButtonColors(
     primary: _darkButtonPrimary,
     primaryForeground: _darkButtonPrimaryForeground,
@@ -312,6 +320,8 @@ class ColorTokens {
   final Color border;
   final Color primaryText;
   final Color secondaryText;
+  final Color accent;
+  final Color accentForeground;
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;
@@ -321,6 +331,8 @@ class ColorTokens {
     required this.border,
     required this.primaryText,
     required this.secondaryText,
+    required this.accent,
+    required this.accentForeground,
     required this.button,
     required this.navigation,
     required this.toast,

--- a/example/lib/widgets/nav_bar.dart
+++ b/example/lib/widgets/nav_bar.dart
@@ -177,9 +177,10 @@ class _RailItemState extends State<_RailItem> {
                 const SizedBox(width: 16),
                 Text(
                   widget.label,
+                  overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    color: navColors.railItemText,
                     fontSize: 16,
+                    color: navColors.railItemText,
                     fontWeight: FontWeight.w500,
                   ),
                 ),
@@ -279,7 +280,12 @@ class _BottomBarItem extends StatelessWidget {
             const SizedBox(height: 2),
             Text(
               label,
-              style: TextStyle(color: color, fontSize: 12, height: 16 / 12),
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: color,
+                fontSize: 12,
+                height: 16 / 12,
+              ),
             ),
           ],
         ),

--- a/example/lib/widgets/toggle.dart
+++ b/example/lib/widgets/toggle.dart
@@ -1,0 +1,310 @@
+import 'package:example/styling.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+// Toggle dimensions
+const double _kTrackWidth = 48;
+const double _kTrackHeight = 26;
+const double _kThumbSize = 20;
+const double _kThumbPadding = 3;
+
+// Small toggle dimensions
+const double _kSmallTrackWidth = 40;
+const double _kSmallTrackHeight = 22;
+const double _kSmallThumbSize = 16;
+const double _kSmallThumbPadding = 3;
+
+// Thumb stretches horizontally by this many pixels when pressed
+const double _kThumbExtension = 5;
+const double _kSmallThumbExtension = 3;
+
+class Toggle extends StatefulWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool _isSmall;
+
+  const Toggle({
+    super.key,
+    required this.value,
+    this.onChanged,
+  }) : _isSmall = false;
+
+  const Toggle.small({
+    super.key,
+    required this.value,
+    this.onChanged,
+  }) : _isSmall = true;
+
+  @override
+  State<Toggle> createState() => _ToggleState();
+}
+
+class _ToggleState extends State<Toggle> with TickerProviderStateMixin {
+  bool _isHovered = false;
+  bool _isFocused = false;
+  bool _needsPositionAnimation = false;
+
+  late final AnimationController _positionController;
+  late final CurvedAnimation _positionAnimation;
+  late final AnimationController _reactionController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _positionController = AnimationController(
+      duration: Styling.durations.normal,
+      vsync: this,
+      value: widget.value ? 1.0 : 0.0,
+    );
+
+    _positionAnimation = CurvedAnimation(
+      parent: _positionController,
+      curve: Curves.ease,
+      reverseCurve: Curves.ease.flipped,
+    );
+
+    _reactionController = AnimationController(
+      duration: Styling.durations.normal,
+      vsync: this,
+    );
+  }
+
+  @override
+  void didUpdateWidget(Toggle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.value != widget.value) {
+      if (_positionController.value == 0.0 ||
+          _positionController.value == 1.0) {
+        _positionAnimation
+          ..curve = Curves.ease
+          ..reverseCurve = Curves.ease.flipped;
+      }
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _positionAnimation.dispose();
+    _positionController.dispose();
+    _reactionController.dispose();
+    super.dispose();
+  }
+
+  bool get _isDisabled => widget.onChanged == null;
+
+  double get _thumbExtension =>
+      widget._isSmall ? _kSmallThumbExtension : _kThumbExtension;
+
+  double get _trackInnerLength {
+    final double trackW = widget._isSmall ? _kSmallTrackWidth : _kTrackWidth;
+    final double thumb = widget._isSmall ? _kSmallThumbSize : _kThumbSize;
+    final double pad = widget._isSmall ? _kSmallThumbPadding : _kThumbPadding;
+
+    return trackW - thumb - pad * 2;
+  }
+
+  void _handleTap() {
+    widget.onChanged?.call(!widget.value);
+    _emitHaptic();
+  }
+
+  void _handleTapDown(TapDownDetails details) {
+    if (!_isDisabled) _reactionController.forward();
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    _reactionController.reverse();
+  }
+
+  void _handleTapCancel() {
+    _reactionController.reverse();
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    if (!_isDisabled) {
+      _reactionController.forward();
+      _emitHaptic();
+    }
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    if (!_isDisabled) {
+      _positionAnimation
+        ..curve = Curves.linear
+        ..reverseCurve = Curves.linear;
+
+      final double delta = details.primaryDelta! / _trackInnerLength;
+
+      _positionController.value += delta;
+    }
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    _reactionController.reverse();
+
+    if (_positionController.value >= 0.5 != widget.value) {
+      widget.onChanged?.call(!widget.value);
+
+      setState(() {
+        _needsPositionAnimation = true;
+      });
+    } else {
+      _positionAnimation
+        ..curve = Curves.easeOutBack
+        ..reverseCurve = Curves.easeOutBack.flipped;
+
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+  }
+
+  void _emitHaptic() {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      HapticFeedback.lightImpact();
+    }
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.space) {
+      _handleTap();
+
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_needsPositionAnimation) {
+      _needsPositionAnimation = false;
+      _positionAnimation
+        ..curve = Curves.easeOutBack
+        ..reverseCurve = Curves.easeOutBack.flipped;
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+
+    final ColorTokens colors = Styling.of(context).colors;
+
+    final double trackW = widget._isSmall ? _kSmallTrackWidth : _kTrackWidth;
+    final double trackH = widget._isSmall ? _kSmallTrackHeight : _kTrackHeight;
+    final double thumbH = widget._isSmall ? _kSmallThumbSize : _kThumbSize;
+    final double pad = widget._isSmall ? _kSmallThumbPadding : _kThumbPadding;
+
+    return Semantics(
+      toggled: widget.value,
+      enabled: !_isDisabled,
+      label: 'Toggle',
+      child: Focus(
+        onFocusChange: (focused) {
+          setState(() {
+            _isFocused = focused;
+          });
+        },
+        onKeyEvent: _isDisabled ? null : _handleKeyEvent,
+        child: MouseRegion(
+          onEnter: (_) {
+            if (!_isDisabled) {
+              setState(() {
+                _isHovered = true;
+              });
+            }
+          },
+          onExit: (_) {
+            if (!_isDisabled) {
+              setState(() {
+                _isHovered = false;
+              });
+            }
+          },
+          cursor: _isDisabled
+              ? SystemMouseCursors.basic
+              : SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: _isDisabled ? null : _handleTap,
+            onTapDown: _isDisabled ? null : _handleTapDown,
+            onTapUp: _isDisabled ? null : _handleTapUp,
+            onTapCancel: _isDisabled ? null : _handleTapCancel,
+            onHorizontalDragStart: _isDisabled ? null : _handleDragStart,
+            onHorizontalDragUpdate: _isDisabled ? null : _handleDragUpdate,
+            onHorizontalDragEnd: _isDisabled ? null : _handleDragEnd,
+            dragStartBehavior: DragStartBehavior.start,
+            child: AnimatedBuilder(
+              animation: Listenable.merge([
+                _positionAnimation,
+                _reactionController,
+              ]),
+              builder: (context, _) {
+                final double t = _positionAnimation.value;
+                final double ext = _reactionController.value * _thumbExtension;
+
+                final double thumbW = thumbH + ext;
+                final double travel = trackW - thumbH - pad * 2 - ext;
+
+                final Color inactiveTrack = _isHovered && !widget.value
+                    ? Color.lerp(colors.border, colors.primaryText, 0.1)!
+                    : colors.border;
+
+                final Color trackColor = Color.lerp(
+                  inactiveTrack,
+                  colors.accent,
+                  t,
+                )!;
+                final Color thumbColor = Color.lerp(
+                  const Color(0xFFFFFFFF),
+                  colors.accentForeground,
+                  t,
+                )!;
+
+                return Opacity(
+                  opacity: _isDisabled ? 0.5 : 1.0,
+                  child: Container(
+                    width: trackW,
+                    height: trackH,
+                    decoration: BoxDecoration(
+                      color: trackColor,
+                      borderRadius: BorderRadius.circular(trackH / 2),
+                      boxShadow: _isFocused && !_isDisabled
+                          ? [
+                              BoxShadow(
+                                color: colors.accent.withValues(alpha: 0.4),
+                                spreadRadius: 2,
+                              ),
+                            ]
+                          : null,
+                    ),
+                    child: Stack(
+                      children: [
+                        Positioned(
+                          left: pad + t * travel,
+                          top: pad,
+                          child: Container(
+                            width: thumbW,
+                            height: thumbH,
+                            decoration: BoxDecoration(
+                              color: thumbColor,
+                              borderRadius: BorderRadius.circular(thumbH / 2),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/test/toggle_test.dart
+++ b/example/test/toggle_test.dart
@@ -1,0 +1,243 @@
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:example/widgets/toggle.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  group('Toggle', () {
+    group('rendering', () {
+      testWidgets('renders without error', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: false, onChanged: (v) {}),
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+
+      testWidgets('renders in on state', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: true, onChanged: (v) {}),
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+
+      testWidgets('renders small variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle.small(value: false, onChanged: (v) {}),
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+
+      testWidgets('renders small variant in on state', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle.small(value: true, onChanged: (v) {}),
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+    });
+
+    group('states', () {
+      testWidgets('has reduced opacity when disabled', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const Toggle(value: false),
+        ));
+
+        final opacity = tester.widget<Opacity>(find.byType(Opacity));
+        expect(opacity.opacity, 0.5);
+      });
+
+      testWidgets('has full opacity when enabled', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: false, onChanged: (v) {}),
+        ));
+
+        final opacity = tester.widget<Opacity>(find.byType(Opacity));
+        expect(opacity.opacity, 1.0);
+      });
+
+      testWidgets('animates when value changes', (tester) async {
+        bool value = false;
+
+        await tester.pumpWidget(wrapWithStyling(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return Toggle(
+                value: value,
+                onChanged: (v) => setState(() => value = v),
+              );
+            },
+          ),
+        ));
+
+        await tester.tap(find.byType(Toggle));
+        await tester.pump();
+        expect(value, isTrue);
+
+        // Let animation run partially
+        await tester.pump(const Duration(milliseconds: 100));
+        // Let animation complete
+        await tester.pumpAndSettle();
+      });
+    });
+
+    group('interaction', () {
+      testWidgets('calls onChanged with toggled value on tap', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(
+            value: false,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.byType(Toggle));
+        await tester.pump();
+
+        expect(received, isTrue);
+      });
+
+      testWidgets('calls onChanged with false when toggling off', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(
+            value: true,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.byType(Toggle));
+        await tester.pump();
+
+        expect(received, isFalse);
+      });
+
+      testWidgets('does not call onChanged when disabled', (tester) async {
+        bool called = false;
+
+        await tester.pumpWidget(wrapWithStyling(
+          const Toggle(value: false),
+        ));
+
+        await tester.tap(find.byType(Toggle));
+        await tester.pump();
+
+        expect(called, isFalse);
+      });
+
+      testWidgets('has Focus widget for keyboard support', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: false, onChanged: (v) {}),
+        ));
+
+        expect(find.byType(Focus), findsWidgets);
+      });
+
+      testWidgets('supports horizontal drag to toggle on', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(
+            value: false,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.timedDrag(
+          find.byType(Toggle),
+          const Offset(40, 0),
+          const Duration(milliseconds: 200),
+        );
+        await tester.pumpAndSettle();
+
+        expect(received, isTrue);
+      });
+
+      testWidgets('supports horizontal drag to toggle off', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(
+            value: true,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.timedDrag(
+          find.byType(Toggle),
+          const Offset(-40, 0),
+          const Duration(milliseconds: 200),
+        );
+        await tester.pumpAndSettle();
+
+        expect(received, isFalse);
+      });
+    });
+
+    group('accessibility', () {
+      testWidgets('has toggled semantics when on', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: true, onChanged: (v) {}),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Toggle));
+        expect(semantics.hasFlag(SemanticsFlag.isToggled), isTrue);
+      });
+
+      testWidgets('does not have toggled semantics when off', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: false, onChanged: (v) {}),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Toggle));
+        expect(semantics.hasFlag(SemanticsFlag.isToggled), isFalse);
+      });
+
+      testWidgets('has enabled semantics when interactive', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: false, onChanged: (v) {}),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Toggle));
+        expect(semantics.hasFlag(SemanticsFlag.isEnabled), isTrue);
+      });
+
+      testWidgets('has disabled semantics when not interactive', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const Toggle(value: false),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(Toggle));
+        expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
+      });
+    });
+
+    group('theming', () {
+      testWidgets('renders in light mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: true, onChanged: (v) {}),
+          brightness: Brightness.light,
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+
+      testWidgets('renders in dark mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          Toggle(value: true, onChanged: (v) {}),
+          brightness: Brightness.dark,
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+    });
+  });
+}

--- a/templates/nav_bar.dart
+++ b/templates/nav_bar.dart
@@ -178,9 +178,10 @@ class _RailItemState extends State<_RailItem> {
                 const SizedBox(width: 16),
                 Text(
                   widget.label,
+                  overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    color: navColors.railItemText,
                     fontSize: 16,
+                    color: navColors.railItemText,
                     fontWeight: FontWeight.w500,
                   ),
                 ),
@@ -280,7 +281,12 @@ class _BottomBarItem extends StatelessWidget {
             const SizedBox(height: 2),
             Text(
               label,
-              style: TextStyle(color: color, fontSize: 12, height: 16 / 12),
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: color,
+                fontSize: 12,
+                height: 16 / 12,
+              ),
             ),
           ],
         ),

--- a/templates/styling.dart
+++ b/templates/styling.dart
@@ -22,6 +22,8 @@ const Color _lightBackground = Color(0xFFFFFFFF);
 const Color _lightBorder = Color(0xFFE4E4E7);
 const Color _lightPrimaryText = Color(0xFF2A2A2A);
 const Color _lightSecondaryText = Color(0xFFACAEAF);
+const Color _lightAccent = Color(0xFF18181B);
+const Color _lightAccentForeground = Color(0xFFFAFAFA);
 
 // Light Theme - Button
 const Color _lightButtonPrimary = Color(0xFF18181B);
@@ -53,6 +55,8 @@ const Color _darkBackground = Color(0xFF303030);
 const Color _darkBorder = Color(0xFF27272A);
 const Color _darkPrimaryText = Color(0xFFFAFAFA);
 const Color _darkSecondaryText = Color(0xFFB2B2B2);
+const Color _darkAccent = Color(0xFFFAFAFA);
+const Color _darkAccentForeground = Color(0xFF18181B);
 
 // Dark Theme - Button
 const Color _darkButtonPrimary = Color(0xFFFAFAFA);
@@ -104,6 +108,8 @@ final ColorTokens _colorsLight = ColorTokens(
   border: _lightBorder,
   primaryText: _lightPrimaryText,
   secondaryText: _lightSecondaryText,
+  accent: _lightAccent,
+  accentForeground: _lightAccentForeground,
   button: ButtonColors(
     primary: _lightButtonPrimary,
     primaryForeground: _lightButtonPrimaryForeground,
@@ -136,6 +142,8 @@ final ColorTokens _colorsDark = ColorTokens(
   border: _darkBorder,
   primaryText: _darkPrimaryText,
   secondaryText: _darkSecondaryText,
+  accent: _darkAccent,
+  accentForeground: _darkAccentForeground,
   button: ButtonColors(
     primary: _darkButtonPrimary,
     primaryForeground: _darkButtonPrimaryForeground,
@@ -178,8 +186,8 @@ class Styling extends InheritedWidget {
   static BreakpointTokens get breakpoints => _breakpoints;
 
   static StylingData of(BuildContext context) {
-    final Styling? styling =
-        context.dependOnInheritedWidgetOfExactType<Styling>();
+    final Styling? styling = context
+        .dependOnInheritedWidgetOfExactType<Styling>();
 
     assert(
       styling != null,
@@ -312,6 +320,8 @@ class ColorTokens {
   final Color border;
   final Color primaryText;
   final Color secondaryText;
+  final Color accent;
+  final Color accentForeground;
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;
@@ -321,6 +331,8 @@ class ColorTokens {
     required this.border,
     required this.primaryText,
     required this.secondaryText,
+    required this.accent,
+    required this.accentForeground,
     required this.button,
     required this.navigation,
     required this.toast,

--- a/templates/toggle.dart
+++ b/templates/toggle.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'styling.dart';
+
+// Toggle dimensions
+const double _kTrackWidth = 48;
+const double _kTrackHeight = 26;
+const double _kThumbSize = 20;
+const double _kThumbPadding = 3;
+
+// Small toggle dimensions
+const double _kSmallTrackWidth = 40;
+const double _kSmallTrackHeight = 22;
+const double _kSmallThumbSize = 16;
+const double _kSmallThumbPadding = 3;
+
+// Thumb stretches horizontally by this many pixels when pressed
+const double _kThumbExtension = 5;
+const double _kSmallThumbExtension = 3;
+
+class Toggle extends StatefulWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool _isSmall;
+
+  const Toggle({
+    super.key,
+    required this.value,
+    this.onChanged,
+  }) : _isSmall = false;
+
+  const Toggle.small({
+    super.key,
+    required this.value,
+    this.onChanged,
+  }) : _isSmall = true;
+
+  @override
+  State<Toggle> createState() => _ToggleState();
+}
+
+class _ToggleState extends State<Toggle> with TickerProviderStateMixin {
+  bool _isHovered = false;
+  bool _isFocused = false;
+  bool _needsPositionAnimation = false;
+
+  late final AnimationController _positionController;
+  late final CurvedAnimation _positionAnimation;
+  late final AnimationController _reactionController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _positionController = AnimationController(
+      duration: Styling.durations.normal,
+      vsync: this,
+      value: widget.value ? 1.0 : 0.0,
+    );
+
+    _positionAnimation = CurvedAnimation(
+      parent: _positionController,
+      curve: Curves.ease,
+      reverseCurve: Curves.ease.flipped,
+    );
+
+    _reactionController = AnimationController(
+      duration: Styling.durations.normal,
+      vsync: this,
+    );
+  }
+
+  @override
+  void didUpdateWidget(Toggle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.value != widget.value) {
+      if (_positionController.value == 0.0 ||
+          _positionController.value == 1.0) {
+        _positionAnimation
+          ..curve = Curves.ease
+          ..reverseCurve = Curves.ease.flipped;
+      }
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _positionAnimation.dispose();
+    _positionController.dispose();
+    _reactionController.dispose();
+    super.dispose();
+  }
+
+  bool get _isDisabled => widget.onChanged == null;
+
+  double get _thumbExtension =>
+      widget._isSmall ? _kSmallThumbExtension : _kThumbExtension;
+
+  double get _trackInnerLength {
+    final double trackW = widget._isSmall ? _kSmallTrackWidth : _kTrackWidth;
+    final double thumb = widget._isSmall ? _kSmallThumbSize : _kThumbSize;
+    final double pad = widget._isSmall ? _kSmallThumbPadding : _kThumbPadding;
+
+    return trackW - thumb - pad * 2;
+  }
+
+  void _handleTap() {
+    widget.onChanged?.call(!widget.value);
+    _emitHaptic();
+  }
+
+  void _handleTapDown(TapDownDetails details) {
+    if (!_isDisabled) _reactionController.forward();
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    _reactionController.reverse();
+  }
+
+  void _handleTapCancel() {
+    _reactionController.reverse();
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    if (!_isDisabled) {
+      _reactionController.forward();
+      _emitHaptic();
+    }
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    if (!_isDisabled) {
+      _positionAnimation
+        ..curve = Curves.linear
+        ..reverseCurve = Curves.linear;
+
+      final double delta = details.primaryDelta! / _trackInnerLength;
+
+      _positionController.value += delta;
+    }
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    _reactionController.reverse();
+
+    if (_positionController.value >= 0.5 != widget.value) {
+      widget.onChanged?.call(!widget.value);
+
+      setState(() {
+        _needsPositionAnimation = true;
+      });
+    } else {
+      _positionAnimation
+        ..curve = Curves.easeOutBack
+        ..reverseCurve = Curves.easeOutBack.flipped;
+
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+  }
+
+  void _emitHaptic() {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      HapticFeedback.lightImpact();
+    }
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.space) {
+      _handleTap();
+
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_needsPositionAnimation) {
+      _needsPositionAnimation = false;
+      _positionAnimation
+        ..curve = Curves.easeOutBack
+        ..reverseCurve = Curves.easeOutBack.flipped;
+      widget.value
+          ? _positionController.forward()
+          : _positionController.reverse();
+    }
+
+    final ColorTokens colors = Styling.of(context).colors;
+
+    final double trackW = widget._isSmall ? _kSmallTrackWidth : _kTrackWidth;
+    final double trackH = widget._isSmall ? _kSmallTrackHeight : _kTrackHeight;
+    final double thumbH = widget._isSmall ? _kSmallThumbSize : _kThumbSize;
+    final double pad = widget._isSmall ? _kSmallThumbPadding : _kThumbPadding;
+
+    return Semantics(
+      toggled: widget.value,
+      enabled: !_isDisabled,
+      label: 'Toggle',
+      child: Focus(
+        onFocusChange: (focused) {
+          setState(() {
+            _isFocused = focused;
+          });
+        },
+        onKeyEvent: _isDisabled ? null : _handleKeyEvent,
+        child: MouseRegion(
+          onEnter: (_) {
+            if (!_isDisabled) {
+              setState(() {
+                _isHovered = true;
+              });
+            }
+          },
+          onExit: (_) {
+            if (!_isDisabled) {
+              setState(() {
+                _isHovered = false;
+              });
+            }
+          },
+          cursor: _isDisabled
+              ? SystemMouseCursors.basic
+              : SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: _isDisabled ? null : _handleTap,
+            onTapDown: _isDisabled ? null : _handleTapDown,
+            onTapUp: _isDisabled ? null : _handleTapUp,
+            onTapCancel: _isDisabled ? null : _handleTapCancel,
+            onHorizontalDragStart: _isDisabled ? null : _handleDragStart,
+            onHorizontalDragUpdate: _isDisabled ? null : _handleDragUpdate,
+            onHorizontalDragEnd: _isDisabled ? null : _handleDragEnd,
+            dragStartBehavior: DragStartBehavior.start,
+            child: AnimatedBuilder(
+              animation: Listenable.merge([
+                _positionAnimation,
+                _reactionController,
+              ]),
+              builder: (context, _) {
+                final double t = _positionAnimation.value;
+                final double ext = _reactionController.value * _thumbExtension;
+
+                final double thumbW = thumbH + ext;
+                final double travel = trackW - thumbH - pad * 2 - ext;
+
+                final Color inactiveTrack = _isHovered && !widget.value
+                    ? Color.lerp(colors.border, colors.primaryText, 0.1)!
+                    : colors.border;
+
+                final Color trackColor = Color.lerp(
+                  inactiveTrack,
+                  colors.accent,
+                  t,
+                )!;
+                final Color thumbColor = Color.lerp(
+                  const Color(0xFFFFFFFF),
+                  colors.accentForeground,
+                  t,
+                )!;
+
+                return Opacity(
+                  opacity: _isDisabled ? 0.5 : 1.0,
+                  child: Container(
+                    width: trackW,
+                    height: trackH,
+                    decoration: BoxDecoration(
+                      color: trackColor,
+                      borderRadius: BorderRadius.circular(trackH / 2),
+                      boxShadow: _isFocused && !_isDisabled
+                          ? [
+                              BoxShadow(
+                                color: colors.accent.withValues(alpha: 0.4),
+                                spreadRadius: 2,
+                              ),
+                            ]
+                          : null,
+                    ),
+                    child: Stack(
+                      children: [
+                        Positioned(
+                          left: pad + t * travel,
+                          top: pad,
+                          child: Container(
+                            width: thumbW,
+                            height: thumbH,
+                            decoration: BoxDecoration(
+                              color: thumbColor,
+                              borderRadius: BorderRadius.circular(thumbH / 2),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Restructures the example app from 11 individual nav items into a 2-tab layout.

## Changes

- Restructured playground into 2-tab navigation