### PR TITLE
refactor(example): restructure playground interface

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,20 +1,11 @@
-import 'package:example/pages/alert_popup_page.dart';
-import 'package:example/pages/search_field_page.dart';
-import 'package:example/pages/toggle_page.dart';
-import 'package:example/pages/popup_page.dart';
-import 'package:example/pages/confirmation_popup_page.dart';
-import 'package:example/pages/copy_button_page.dart';
-import 'package:example/pages/empty_state_page.dart';
+import 'package:example/pages/components_page.dart';
+import 'package:example/pages/docs_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:example/styling.dart';
 import 'package:example/widgets/button.dart';
 import 'package:example/widgets/nav_bar.dart';
-import 'package:example/pages/button_page.dart';
-import 'package:example/pages/spinner_page.dart';
-import 'package:example/pages/nav_bar_page.dart';
-import 'package:example/pages/toast_page.dart';
 
 final _brightnessNotifier = ValueNotifier(Brightness.light);
 
@@ -66,59 +57,14 @@ class _PlaygroundShellState extends State<PlaygroundShell> {
 
   static const _pages = [
     _PageInfo(
-      title: 'Button',
-      icon: Icons.smart_button_outlined,
-      page: ButtonPage(),
+      title: 'Components',
+      icon: TablerIcons.layout_dashboard,
+      page: ComponentsPage(),
     ),
     _PageInfo(
-      title: 'Spinner',
-      icon: Icons.refresh,
-      page: SpinnerPage(),
-    ),
-    _PageInfo(
-      title: 'NavBar',
-      icon: Icons.menu,
-      page: NavBarPage(),
-    ),
-    _PageInfo(
-      title: 'Toast',
-      icon: Icons.notifications_outlined,
-      page: ToastPage(),
-    ),
-    _PageInfo(
-      title: 'Empty State',
-      icon: Icons.inbox_outlined,
-      page: EmptyStatePage(),
-    ),
-    _PageInfo(
-      title: 'Confirmation',
-      icon: Icons.help_outline,
-      page: ConfirmationPopupPage(),
-    ),
-    _PageInfo(
-      title: 'Copy Button',
-      icon: Icons.copy,
-      page: CopyButtonPage(),
-    ),
-    _PageInfo(
-      title: 'Alert Popup',
-      icon: Icons.campaign_outlined,
-      page: AlertPopupPage(),
-    ),
-    _PageInfo(
-      title: 'Popup',
-      icon: Icons.web_asset_outlined,
-      page: PopupPage(),
-    ),
-    _PageInfo(
-      title: 'Search Field',
-      icon: Icons.search,
-      page: SearchFieldPage(),
-    ),
-    _PageInfo(
-      title: 'Toggle',
-      icon: Icons.toggle_on_outlined,
-      page: TogglePage(),
+      title: 'Docs',
+      icon: TablerIcons.book,
+      page: DocsPage(),
     ),
   ];
 
@@ -193,9 +139,8 @@ class _PlaygroundShellState extends State<PlaygroundShell> {
 
             return Button.small(
               onPressed: () {
-                _brightnessNotifier.value = isDark
-                    ? Brightness.light
-                    : Brightness.dark;
+                _brightnessNotifier.value =
+                    isDark ? Brightness.light : Brightness.dark;
               },
               icon: Icon(
                 isDark ? Icons.light_mode : Icons.dark_mode,

--- a/example/lib/pages/alert_popup_page.dart
+++ b/example/lib/pages/alert_popup_page.dart
@@ -7,175 +7,172 @@ class AlertPopupPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Success',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.check_circle_outline,
-                    size: 48,
-                    color: Colors.green.shade300,
-                  ),
-                  title: 'Payment successful',
-                  description:
-                      'Your payment of \$49.99 has been processed successfully.',
-                  action: Button(
-                    label: 'Done',
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Success',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.check_circle_outline,
+                  size: 48,
+                  color: Colors.green.shade300,
+                ),
+                title: 'Payment successful',
+                description:
+                    'Your payment of \$49.99 has been processed successfully.',
+                action: Button(
+                  label: 'Done',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'Error',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.error_outline,
-                    size: 48,
-                    color: Colors.red.shade300,
-                  ),
-                  title: 'Something went wrong',
-                  description:
-                      'We couldn\'t process your request. Please try again later.',
-                  action: Button(
-                    label: 'Try again',
-                    variant: ButtonVariant.destructive,
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'Error',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.error_outline,
+                  size: 48,
+                  color: Colors.red.shade300,
+                ),
+                title: 'Something went wrong',
+                description:
+                    'We couldn\'t process your request. Please try again later.',
+                action: Button(
+                  label: 'Try again',
+                  variant: ButtonVariant.destructive,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'Warning',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.warning_amber_rounded,
-                    size: 48,
-                    color: Colors.orange.shade300,
-                  ),
-                  title: 'Session expiring soon',
-                  description:
-                      'Your session will expire in 5 minutes. Save your work to avoid losing progress.',
-                  action: Button(
-                    label: 'Got it',
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'Warning',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.warning_amber_rounded,
+                  size: 48,
+                  color: Colors.orange.shade300,
+                ),
+                title: 'Session expiring soon',
+                description:
+                    'Your session will expire in 5 minutes. Save your work to avoid losing progress.',
+                action: Button(
+                  label: 'Got it',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'Info',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.info_outline,
-                    size: 48,
-                    color: Colors.blue.shade300,
-                  ),
-                  title: 'New update available',
-                  description:
-                      'Version 2.0 is available with new features and improvements.',
-                  action: Button(
-                    label: 'Update now',
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'Info',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.info_outline,
+                  size: 48,
+                  color: Colors.blue.shade300,
+                ),
+                title: 'New update available',
+                description:
+                    'Version 2.0 is available with new features and improvements.',
+                action: Button(
+                  label: 'Update now',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'No icon',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  title: 'Terms updated',
-                  description:
-                      'We\'ve updated our terms of service. Please review them at your convenience.',
-                  action: Button(
-                    label: 'OK',
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'No icon',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                title: 'Terms updated',
+                description:
+                    'We\'ve updated our terms of service. Please review them at your convenience.',
+                action: Button(
+                  label: 'OK',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'No description',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.cloud_done_outlined,
-                    size: 48,
-                    color: Colors.green.shade300,
-                  ),
-                  title: 'All changes saved',
-                  action: Button(
-                    label: 'OK',
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'No description',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.cloud_done_outlined,
+                  size: 48,
+                  color: Colors.green.shade300,
+                ),
+                title: 'All changes saved',
+                action: Button(
+                  label: 'OK',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'No action (tap outside to dismiss)',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.hourglass_bottom,
-                    size: 48,
-                    color: Colors.grey.shade400,
-                  ),
-                  title: 'Processing your request',
-                  description: 'This may take a moment. Tap outside to dismiss.',
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'No action (tap outside to dismiss)',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.hourglass_bottom,
+                  size: 48,
+                  color: Colors.grey.shade400,
+                ),
+                title: 'Processing your request',
+                description: 'This may take a moment. Tap outside to dismiss.',
+              );
+            },
+            label: 'Show Alert',
           ),
-          _buildSection(
-            title: 'Minimal (title only)',
-            child: Button.small(
-              onPressed: () {
-                AlertPopup.show(
-                  context: context,
-                  title: 'Copied to clipboard',
-                );
-              },
-              label: 'Show Alert',
-            ),
+        ),
+        _buildSection(
+          title: 'Minimal (title only)',
+          child: Button.small(
+            onPressed: () {
+              AlertPopup.show(
+                context: context,
+                title: 'Copied to clipboard',
+              );
+            },
+            label: 'Show Alert',
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/button_page.dart
+++ b/example/lib/pages/button_page.dart
@@ -19,132 +19,144 @@ class _ButtonPageState extends State<ButtonPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Variants',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: () {},
-                  label: 'Primary',
-                  variant: ButtonVariant.primary,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Secondary',
-                  variant: ButtonVariant.secondary,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Destructive',
-                  variant: ButtonVariant.destructive,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Outline',
-                  variant: ButtonVariant.outline,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Ghost',
-                  variant: ButtonVariant.ghost,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Link',
-                  variant: ButtonVariant.link,
-                ),
-              ],
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Variants',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: () {},
+                label: 'Primary',
+                variant: ButtonVariant.primary,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Secondary',
+                variant: ButtonVariant.secondary,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Destructive',
+                variant: ButtonVariant.destructive,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Outline',
+                variant: ButtonVariant.outline,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Ghost',
+                variant: ButtonVariant.ghost,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Link',
+                variant: ButtonVariant.link,
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Sizes',
-            child: Row(
-              children: [
-                Expanded(
-                  child: Button(
-                    onPressed: () {},
-                    label: 'Default size',
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Button.small(
+        ),
+        _buildSection(
+          title: 'Sizes',
+          child: Row(
+            children: [
+              Expanded(
+                child: Button(
                   onPressed: () {},
-                  label: 'Small size',
+                  label: 'Default size',
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(width: 12),
+              Button.small(
+                onPressed: () {},
+                label: 'Small size',
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'With icon',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: () {},
-                  label: 'Settings',
-                  icon: const Icon(Icons.settings),
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Delete',
-                  icon: const Icon(Icons.delete),
-                  variant: ButtonVariant.destructive,
-                ),
-                Button.small(
-                  onPressed: () {},
-                  label: 'Add new',
-                  icon: const Icon(Icons.add),
-                  variant: ButtonVariant.outline,
-                ),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'With icon',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: () {},
+                label: 'Settings',
+                icon: const Icon(Icons.settings),
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Delete',
+                icon: const Icon(Icons.delete),
+                variant: ButtonVariant.destructive,
+              ),
+              Button.small(
+                onPressed: () {},
+                label: 'Add new',
+                icon: const Icon(Icons.add),
+                variant: ButtonVariant.outline,
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Loading state',
-            child: Row(
-              children: [
-                Button.small(
-                  onPressed: _simulateLoading,
-                  label: _loading ? 'Loading...' : 'Click to load',
-                  loading: _loading,
-                ),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Loading state',
+          child: Row(
+            children: [
+              Button.small(
+                onPressed: _simulateLoading,
+                label: _loading ? 'Loading...' : 'Click to load',
+                loading: _loading,
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Disabled state',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: null,
-                  label: 'Disabled primary',
-                  variant: ButtonVariant.primary,
-                ),
-                Button.small(
-                  onPressed: null,
-                  label: 'Disabled secondary',
-                  variant: ButtonVariant.secondary,
-                ),
-                Button.small(
-                  onPressed: null,
-                  label: 'Disabled outline',
-                  variant: ButtonVariant.outline,
-                ),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Disabled state',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: null,
+                label: 'Primary',
+                variant: ButtonVariant.primary,
+              ),
+              Button.small(
+                onPressed: null,
+                label: 'Secondary',
+                variant: ButtonVariant.secondary,
+              ),
+              Button.small(
+                onPressed: null,
+                label: 'Destructive',
+                variant: ButtonVariant.destructive,
+              ),
+              Button.small(
+                onPressed: null,
+                label: 'Outline',
+                variant: ButtonVariant.outline,
+              ),
+              Button.small(
+                onPressed: null,
+                label: 'Ghost',
+                variant: ButtonVariant.ghost,
+              ),
+              Button.small(
+                onPressed: null,
+                label: 'Link',
+                variant: ButtonVariant.link,
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/components_page.dart
+++ b/example/lib/pages/components_page.dart
@@ -1,0 +1,123 @@
+import 'package:example/pages/alert_popup_page.dart';
+import 'package:example/pages/button_page.dart';
+import 'package:example/pages/confirmation_popup_page.dart';
+import 'package:example/pages/copy_button_page.dart';
+import 'package:example/pages/empty_state_page.dart';
+import 'package:example/pages/nav_bar_page.dart';
+import 'package:example/pages/popup_page.dart';
+import 'package:example/pages/search_field_page.dart';
+import 'package:example/pages/spinner_page.dart';
+import 'package:example/pages/toast_page.dart';
+import 'package:example/pages/toggle_page.dart';
+import 'package:example/styling.dart';
+import 'package:flutter/widgets.dart';
+
+class ComponentsPage extends StatelessWidget {
+  const ComponentsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final styling = Styling.of(context);
+    final isDesktop =
+        MediaQuery.of(context).size.width >= Styling.breakpoints.desktop;
+
+    final sections = [
+      _componentSection('Button', styling, const ButtonPage()),
+      _componentSection('Toggle', styling, const TogglePage()),
+      _componentSection('Copy Button', styling, const CopyButtonPage()),
+      _componentSection('Search Field', styling, const SearchFieldPage()),
+      _componentSection('Spinner', styling, const SpinnerPage()),
+      _componentSection('Toast', styling, const ToastPage()),
+      _componentSection('Alert Popup', styling, const AlertPopupPage()),
+      _componentSection(
+        'Confirmation Popup',
+        styling,
+        const ConfirmationPopupPage(),
+      ),
+      _componentSection('Popup', styling, const PopupPage()),
+      _componentSection('Empty State', styling, const EmptyStatePage()),
+      _componentSection('NavBar', styling, const NavBarPage()),
+    ];
+
+    if (!isDesktop) {
+      return SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (int i = 0; i < sections.length; i++) ...[
+              sections[i],
+              if (i < sections.length - 1) const SizedBox(height: 24),
+            ],
+          ],
+        ),
+      );
+    }
+
+    final left = <Widget>[];
+    final right = <Widget>[];
+    for (int i = 0; i < sections.length; i++) {
+      (i.isEven ? left : right).add(sections[i]);
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                for (int i = 0; i < left.length; i++) ...[
+                  left[i],
+                  if (i < left.length - 1) const SizedBox(height: 24),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 24),
+          Expanded(
+            child: Column(
+              children: [
+                for (int i = 0; i < right.length; i++) ...[
+                  right[i],
+                  if (i < right.length - 1) const SizedBox(height: 24),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _componentSection(
+    String title,
+    StylingData styling,
+    Widget child,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: styling.colors.secondaryText,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            border: Border.all(color: styling.colors.border),
+            borderRadius: BorderRadius.circular(Styling.radii.medium),
+          ),
+          child: child,
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/pages/confirmation_popup_page.dart
+++ b/example/lib/pages/confirmation_popup_page.dart
@@ -8,164 +8,161 @@ class ConfirmationPopupPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Approve Feature',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.check_circle_outline,
-                    size: 48,
-                    color: Colors.green.shade300,
-                  ),
-                  title: 'Sure to approve this feature?',
-                  description:
-                      'Once approved, it will be visible to the public.',
-                  confirmLabel: 'Yes, approve',
-                  cancelLabel: 'Cancel',
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      message: 'Feature approved.',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Approve Feature',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.check_circle_outline,
+                  size: 48,
+                  color: Colors.green.shade300,
+                ),
+                title: 'Sure to approve this feature?',
+                description:
+                    'Once approved, it will be visible to the public.',
+                confirmLabel: 'Yes, approve',
+                cancelLabel: 'Cancel',
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    message: 'Feature approved.',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-          _buildSection(
-            title: 'Delete Item',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.delete_outline,
-                    size: 48,
-                    color: Colors.red.shade300,
-                  ),
-                  title: 'Delete this item?',
-                  description: 'This action cannot be undone.',
-                  confirmLabel: 'Delete',
-                  cancelLabel: 'Keep it',
-                  destructive: true,
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      message: 'Item deleted',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+        ),
+        _buildSection(
+          title: 'Delete Item',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.delete_outline,
+                  size: 48,
+                  color: Colors.red.shade300,
+                ),
+                title: 'Delete this item?',
+                description: 'This action cannot be undone.',
+                confirmLabel: 'Delete',
+                cancelLabel: 'Keep it',
+                destructive: true,
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    message: 'Item deleted',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-          _buildSection(
-            title: 'Logout',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.logout,
-                    size: 48,
-                    color: Colors.orange.shade300,
-                  ),
-                  title: 'Log out of your account?',
-                  description:
-                      'You will need to sign in again to access your data.',
-                  confirmLabel: 'Log out',
-                  destructive: true,
-                  cancelLabel: 'Stay',
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      message: 'Logged out',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+        ),
+        _buildSection(
+          title: 'Logout',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.logout,
+                  size: 48,
+                  color: Colors.orange.shade300,
+                ),
+                title: 'Log out of your account?',
+                description:
+                    'You will need to sign in again to access your data.',
+                confirmLabel: 'Log out',
+                destructive: true,
+                cancelLabel: 'Stay',
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    message: 'Logged out',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-          _buildSection(
-            title: 'Discard Changes',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  icon: Icon(
-                    Icons.edit_off_outlined,
-                    size: 48,
-                    color: Colors.grey.shade400,
-                  ),
-                  title: 'Discard unsaved changes?',
-                  description: 'Your changes will be lost.',
-                  confirmLabel: 'Discard',
-                  cancelLabel: 'Keep editing',
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      type: ToastType.info,
-                      message: 'Changes discarded',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+        ),
+        _buildSection(
+          title: 'Discard Changes',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                icon: Icon(
+                  Icons.edit_off_outlined,
+                  size: 48,
+                  color: Colors.grey.shade400,
+                ),
+                title: 'Discard unsaved changes?',
+                description: 'Your changes will be lost.',
+                confirmLabel: 'Discard',
+                cancelLabel: 'Keep editing',
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    type: ToastType.info,
+                    message: 'Changes discarded',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-          _buildSection(
-            title: 'Unsized Icon (auto 48x48)',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  icon: Icon(Icons.warning_amber, color: Colors.amber),
-                  title: 'Icon without size',
-                  description: 'The icon is passed without explicit size.',
-                  confirmLabel: 'Confirm',
-                  cancelLabel: 'Cancel',
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      message: 'Confirmed',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+        ),
+        _buildSection(
+          title: 'Unsized Icon (auto 48x48)',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                icon: Icon(Icons.warning_amber, color: Colors.amber),
+                title: 'Icon without size',
+                description: 'The icon is passed without explicit size.',
+                confirmLabel: 'Confirm',
+                cancelLabel: 'Cancel',
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    message: 'Confirmed',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-          _buildSection(
-            title: 'Minimal (no icon, no description)',
-            child: Button.small(
-              onPressed: () {
-                ConfirmationPopup.show(
-                  context: context,
-                  title: 'Are you sure?',
-                  confirmLabel: 'Yes',
-                  cancelLabel: 'No',
-                  onConfirm: () {
-                    showToast(
-                      context: context,
-                      message: 'Clicked yes',
-                    );
-                  },
-                );
-              },
-              label: 'Show Dialog',
-            ),
+        ),
+        _buildSection(
+          title: 'Minimal (no icon, no description)',
+          child: Button.small(
+            onPressed: () {
+              ConfirmationPopup.show(
+                context: context,
+                title: 'Are you sure?',
+                confirmLabel: 'Yes',
+                cancelLabel: 'No',
+                onConfirm: () {
+                  showToast(
+                    context: context,
+                    message: 'Clicked yes',
+                  );
+                },
+              );
+            },
+            label: 'Show Dialog',
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/copy_button_page.dart
+++ b/example/lib/pages/copy_button_page.dart
@@ -10,37 +10,34 @@ class CopyButtonPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final styling = Styling.of(context);
 
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Default',
-            child: Row(
-              children: [
-                Text(
-                  'kamran@userorient.com',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: styling.colors.primaryText,
-                  ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Default',
+          child: Row(
+            children: [
+              Text(
+                'kamran@userorient.com',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: styling.colors.primaryText,
                 ),
-                const SizedBox(width: 8),
-                CopyButton(
-                  value: 'kamran@userorient.com',
-                  onCopied: () {
-                    showToast(
-                      context: context,
-                      message: 'Copied to clipboard',
-                    );
-                  },
-                ),
-              ],
-            ),
+              ),
+              const SizedBox(width: 8),
+              CopyButton(
+                value: 'kamran@userorient.com',
+                onCopied: () {
+                  showToast(
+                    context: context,
+                    message: 'Copied to clipboard',
+                  );
+                },
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/docs_page.dart
+++ b/example/lib/pages/docs_page.dart
@@ -1,0 +1,186 @@
+import 'package:example/styling.dart';
+import 'package:flutter/widgets.dart';
+
+class DocsPage extends StatelessWidget {
+  const DocsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final styling = Styling.of(context);
+    final codeBackground = styling.colors.border.withValues(alpha: 0.3);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Orient UI',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              color: styling.colors.primaryText,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Design system for Flutter without Material or Cupertino.',
+            style: TextStyle(
+              fontSize: 16,
+              color: styling.colors.secondaryText,
+            ),
+          ),
+          const SizedBox(height: 32),
+          _buildSection(
+            styling: styling,
+            title: 'Getting Started',
+            children: [
+              _buildStep(styling, '1', 'Install the CLI', codeBackground,
+                  'dart pub global activate orient_ui'),
+              _buildStep(styling, '2', 'Initialize', codeBackground,
+                  'orient_ui init'),
+              _buildStep(
+                  styling,
+                  '3',
+                  'Wrap your app',
+                  codeBackground,
+                  'Styling(\n'
+                      '  brightness: Brightness.light,\n'
+                      '  child: MaterialApp(\n'
+                      '    home: MyHomePage(),\n'
+                      '  ),\n'
+                      ')'),
+              _buildStep(styling, '4', 'Add components', codeBackground,
+                  'orient_ui add button'),
+            ],
+          ),
+          _buildSection(
+            styling: styling,
+            title: 'Commands',
+            children: [
+              _buildCodeBlock(
+                  codeBackground,
+                  styling,
+                  'orient_ui init          # Initialize styling\n'
+                      'orient_ui add           # List components\n'
+                      'orient_ui add <widget>  # Add a component'),
+            ],
+          ),
+          _buildSection(
+            styling: styling,
+            title: 'Components',
+            children: [
+              _buildComponentList(styling, [
+                'Button (6 variants)',
+                'Toggle',
+                'CopyButton',
+                'SearchField',
+                'Spinner',
+                'Toast',
+                'AlertPopup',
+                'ConfirmationPopup',
+                'Popup',
+                'EmptyState',
+                'NavBar',
+              ]),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required StylingData styling,
+    required String title,
+    required List<Widget> children,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: styling.colors.primaryText,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStep(
+    StylingData styling,
+    String number,
+    String title,
+    Color codeBackground,
+    String code,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$number. $title',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: styling.colors.primaryText,
+            ),
+          ),
+          const SizedBox(height: 8),
+          _buildCodeBlock(codeBackground, styling, code),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCodeBlock(
+    Color background,
+    StylingData styling,
+    String code,
+  ) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(Styling.radii.small),
+      ),
+      child: Text(
+        code,
+        style: TextStyle(
+          fontSize: 13,
+          fontFamily: 'monospace',
+          color: styling.colors.primaryText,
+          height: 1.6,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComponentList(StylingData styling, List<String> components) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: components
+          .map((name) => Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  name,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: styling.colors.primaryText,
+                  ),
+                ),
+              ))
+          .toList(),
+    );
+  }
+}

--- a/example/lib/pages/empty_state_page.dart
+++ b/example/lib/pages/empty_state_page.dart
@@ -7,44 +7,41 @@ class EmptyStatePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Default',
-            child: EmptyState(
-              icon: Icon(
-                Icons.notifications_off_outlined,
-                size: 48,
-                color: Colors.black26,
-              ),
-              title: 'No notifications',
-              description:
-                  'When we send you notifications, you\'ll be able to see them here.',
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Default',
+          child: EmptyState(
+            icon: Icon(
+              Icons.notifications_off_outlined,
+              size: 48,
+              color: Colors.black26,
+            ),
+            title: 'No notifications',
+            description:
+                'When we send you notifications, you\'ll be able to see them here.',
+          ),
+        ),
+        _buildSection(
+          title: 'With Action',
+          child: EmptyState(
+            icon: Icon(
+              Icons.gps_off_outlined,
+              size: 48,
+              color: Colors.black26,
+            ),
+            title: 'Location Disabled',
+            description:
+                'Please enable GPS services from settings of your device.',
+            action: Button.small(
+              onPressed: () {},
+              icon: Icon(Icons.settings),
+              label: 'Open Settings',
             ),
           ),
-          _buildSection(
-            title: 'With Action',
-            child: EmptyState(
-              icon: Icon(
-                Icons.gps_off_outlined,
-                size: 48,
-                color: Colors.black26,
-              ),
-              title: 'Location Disabled',
-              description:
-                  'Please enable GPS services from settings of your device.',
-              action: Button.small(
-                onPressed: () {},
-                icon: Icon(Icons.settings),
-                label: 'Open Settings',
-              ),
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/nav_bar_page.dart
+++ b/example/lib/pages/nav_bar_page.dart
@@ -20,98 +20,95 @@ class _NavBarPageState extends State<NavBarPage> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Mobile (Bottom Bar)',
-            child: _buildPreviewContainer(
-              width: 375,
-              height: 667,
-              child: NavBar(
-                currentIndex: _mobileIndex,
-                onTap: (i) => setState(() => _mobileIndex = i),
-                items: _demoItems,
-                body: _buildDemoBody('Mobile View', _mobileIndex),
-              ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Mobile (Bottom Bar)',
+          child: _buildPreviewContainer(
+            width: 375,
+            height: 667,
+            child: NavBar(
+              currentIndex: _mobileIndex,
+              onTap: (i) => setState(() => _mobileIndex = i),
+              items: _demoItems,
+              body: _buildDemoBody('Mobile View', _mobileIndex),
             ),
           ),
-          _buildSection(
-            title: 'Desktop (Rail)',
-            child: _buildPreviewContainer(
-              width: 800,
-              height: 500,
-              child: NavBar(
-                currentIndex: _desktopIndex,
-                onTap: (i) => setState(() => _desktopIndex = i),
-                items: _demoItems,
-                railHeader: const Text(
-                  'Logo',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
-                ),
-                body: _buildDemoBody('Desktop View', _desktopIndex),
+        ),
+        _buildSection(
+          title: 'Desktop (Rail)',
+          child: _buildPreviewContainer(
+            width: 800,
+            height: 500,
+            child: NavBar(
+              currentIndex: _desktopIndex,
+              onTap: (i) => setState(() => _desktopIndex = i),
+              items: _demoItems,
+              railHeader: const Text(
+                'Logo',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
               ),
+              body: _buildDemoBody('Desktop View', _desktopIndex),
             ),
           ),
-          _buildSection(
-            title: 'With Header & Footer',
-            child: _buildPreviewContainer(
-              width: 800,
-              height: 500,
-              child: NavBar(
-                currentIndex: 0,
-                onTap: (_) {},
-                items: _demoItems,
-                railHeader: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFF18181B),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: const Icon(Icons.bolt, color: Colors.white, size: 20),
+        ),
+        _buildSection(
+          title: 'With Header & Footer',
+          child: _buildPreviewContainer(
+            width: 800,
+            height: 500,
+            child: NavBar(
+              currentIndex: 0,
+              onTap: (_) {},
+              items: _demoItems,
+              railHeader: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF18181B),
+                      borderRadius: BorderRadius.circular(8),
                     ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      'Acme Inc',
-                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                    child: const Icon(Icons.bolt, color: Colors.white, size: 20),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Acme Inc',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                  ),
+                ],
+              ),
+              railFooter: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF4F4F5),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 16,
+                      backgroundColor: Color(0xFFE4E4E7),
+                      child: Icon(Icons.person, size: 18, color: Color(0xFF71717A)),
+                    ),
+                    SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'John Doe',
+                        style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+                      ),
                     ),
                   ],
                 ),
-                railFooter: Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFF4F4F5),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: const Row(
-                    children: [
-                      CircleAvatar(
-                        radius: 16,
-                        backgroundColor: Color(0xFFE4E4E7),
-                        child: Icon(Icons.person, size: 18, color: Color(0xFF71717A)),
-                      ),
-                      SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          'John Doe',
-                          style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                body: _buildDemoBody('With Header & Footer', 0),
               ),
+              body: _buildDemoBody('With Header & Footer', 0),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/popup_page.dart
+++ b/example/lib/pages/popup_page.dart
@@ -8,26 +8,23 @@ class PopupPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Comments',
-            child: Button.small(
-              onPressed: () {
-                Popup.show(
-                  context: context,
-                  title: 'Comments (3)',
-                  child: _CommentsList(),
-                );
-              },
-              label: 'Show Popup',
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Comments',
+          child: Button.small(
+            onPressed: () {
+              Popup.show(
+                context: context,
+                title: 'Comments (3)',
+                child: _CommentsList(),
+              );
+            },
+            label: 'Show Popup',
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/search_field_page.dart
+++ b/example/lib/pages/search_field_page.dart
@@ -17,23 +17,8 @@ class _SearchFieldPageState extends State<SearchFieldPage> {
     ('userorient_flutter', 'In-app feedback and feature requests'),
     ('flutter_bloc', 'State management with BLoC pattern'),
     ('riverpod', 'Reactive caching and data-binding'),
-    ('provider', 'Simple state management'),
-    ('get_it', 'Service locator for dependency injection'),
     ('dio', 'Powerful HTTP client'),
-    ('http', 'Composable HTTP client'),
-    ('shared_preferences', 'Persistent key-value storage'),
-    ('hive', 'Lightweight and fast key-value database'),
-    ('sqflite', 'SQLite plugin for Flutter'),
     ('go_router', 'Declarative routing'),
-    ('auto_route', 'Code generation for routing'),
-    ('freezed', 'Code generation for immutable classes'),
-    ('json_serializable', 'JSON serialization code generation'),
-    ('flutter_hooks', 'React-like hooks for Flutter'),
-    ('cached_network_image', 'Image caching and loading'),
-    ('flutter_svg', 'SVG rendering'),
-    ('lottie', 'Lottie animations'),
-    ('intl', 'Internationalization and localization'),
-    ('url_launcher', 'Launch URLs in browser'),
   ];
 
   List<(String, String)> get _filteredPackages {
@@ -53,46 +38,24 @@ class _SearchFieldPageState extends State<SearchFieldPage> {
 
   @override
   Widget build(BuildContext context) {
-    final styling = Styling.of(context);
-
-    return Padding(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'SearchField',
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: styling.colors.primaryText,
-            ),
-          ),
-          const SizedBox(height: 24),
-          SearchField(
-            controller: _controller,
-            placeholder: 'Search packages...',
-            onChanged: (value) {
-              setState(() {
-                _query = value;
-              });
-            },
-          ),
-          const SizedBox(height: 16),
-          Expanded(
-            child: ListView.builder(
-              itemCount: _filteredPackages.length,
-              itemBuilder: (context, index) {
-                final package = _filteredPackages[index];
-                return _PackageItem(
-                  name: package.$1,
-                  description: package.$2,
-                );
-              },
-            ),
-          ),
-        ],
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SearchField(
+          controller: _controller,
+          placeholder: 'Search packages...',
+          onChanged: (value) {
+            setState(() {
+              _query = value;
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        ..._filteredPackages.map((package) => _PackageItem(
+              name: package.$1,
+              description: package.$2,
+            )),
+      ],
     );
   }
 }

--- a/example/lib/pages/spinner_page.dart
+++ b/example/lib/pages/spinner_page.dart
@@ -6,90 +6,87 @@ class SpinnerPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Default',
-            child: const Row(
-              children: [
-                Spinner(color: Color(0xFF18181B)),
-              ],
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Default',
+          child: const Row(
+            children: [
+              Spinner(color: Color(0xFF18181B)),
+            ],
           ),
-          _buildSection(
-            title: 'Colors',
-            child: const Row(
-              children: [
-                Spinner(color: Color(0xFF18181B)),
-                SizedBox(width: 24),
-                Spinner(color: Color(0xFFEF4444)),
-                SizedBox(width: 24),
-                Spinner(color: Color(0xFF3B82F6)),
-                SizedBox(width: 24),
-                Spinner(color: Color(0xFF22C55E)),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Colors',
+          child: const Row(
+            children: [
+              Spinner(color: Color(0xFF18181B)),
+              SizedBox(width: 24),
+              Spinner(color: Color(0xFFEF4444)),
+              SizedBox(width: 24),
+              Spinner(color: Color(0xFF3B82F6)),
+              SizedBox(width: 24),
+              Spinner(color: Color(0xFF22C55E)),
+            ],
           ),
-          _buildSection(
-            title: 'Sizes',
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: const Spinner(color: Color(0xFF18181B)),
-                ),
-                const SizedBox(width: 24),
-                SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: const Spinner(color: Color(0xFF18181B)),
-                ),
-                const SizedBox(width: 24),
-                SizedBox(
-                  width: 32,
-                  height: 32,
-                  child: const Spinner(color: Color(0xFF18181B)),
-                ),
-                const SizedBox(width: 24),
-                SizedBox(
-                  width: 48,
-                  height: 48,
-                  child: const Spinner(color: Color(0xFF18181B)),
-                ),
-              ],
-            ),
-          ),
-          _buildSection(
-            title: 'Usage in context',
-            child: Container(
-              padding: const EdgeInsets.all(24),
-              decoration: BoxDecoration(
-                color: const Color(0xFFF4F4F5),
-                borderRadius: BorderRadius.circular(12),
+        ),
+        _buildSection(
+          title: 'Sizes',
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: const Spinner(color: Color(0xFF18181B)),
               ),
-              child: const Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Spinner(color: Color(0xFF18181B)),
-                  SizedBox(width: 12),
-                  Text(
-                    'Loading content...',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Color(0xFF71717A),
-                    ),
+              const SizedBox(width: 24),
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: const Spinner(color: Color(0xFF18181B)),
+              ),
+              const SizedBox(width: 24),
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: const Spinner(color: Color(0xFF18181B)),
+              ),
+              const SizedBox(width: 24),
+              SizedBox(
+                width: 48,
+                height: 48,
+                child: const Spinner(color: Color(0xFF18181B)),
+              ),
+            ],
+          ),
+        ),
+        _buildSection(
+          title: 'Usage in context',
+          child: Container(
+            padding: const EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF4F4F5),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Spinner(color: Color(0xFF18181B)),
+                SizedBox(width: 12),
+                Text(
+                  'Loading content...',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Color(0xFF71717A),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/toast_page.dart
+++ b/example/lib/pages/toast_page.dart
@@ -7,112 +7,109 @@ class ToastPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Toast Types',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Successfully saved!',
-                    type: ToastType.success,
-                  ),
-                  label: 'Success',
-                  variant: ButtonVariant.primary,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Toast Types',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Successfully saved!',
+                  type: ToastType.success,
                 ),
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Something went wrong',
-                    type: ToastType.error,
-                  ),
-                  label: 'Error',
-                  variant: ButtonVariant.destructive,
+                label: 'Success',
+                variant: ButtonVariant.primary,
+              ),
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Something went wrong',
+                  type: ToastType.error,
                 ),
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Here is some info',
-                    type: ToastType.info,
-                  ),
-                  label: 'Info',
-                  variant: ButtonVariant.secondary,
+                label: 'Error',
+                variant: ButtonVariant.destructive,
+              ),
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Here is some info',
+                  type: ToastType.info,
                 ),
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Please be careful',
-                    type: ToastType.warning,
-                  ),
-                  label: 'Warning',
-                  variant: ButtonVariant.outline,
+                label: 'Info',
+                variant: ButtonVariant.secondary,
+              ),
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Please be careful',
+                  type: ToastType.warning,
                 ),
-              ],
-            ),
+                label: 'Warning',
+                variant: ButtonVariant.outline,
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Position',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Toast at top',
-                    position: ToastPosition.top,
-                  ),
-                  label: 'Top',
-                  variant: ButtonVariant.secondary,
+        ),
+        _buildSection(
+          title: 'Position',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Toast at top',
+                  position: ToastPosition.top,
                 ),
-                Button.small(
-                  onPressed: () => showToast(
-                    context: context,
-                    message: 'Toast at bottom',
-                    position: ToastPosition.bottom,
-                  ),
-                  label: 'Bottom',
-                  variant: ButtonVariant.secondary,
+                label: 'Top',
+                variant: ButtonVariant.secondary,
+              ),
+              Button.small(
+                onPressed: () => showToast(
+                  context: context,
+                  message: 'Toast at bottom',
+                  position: ToastPosition.bottom,
                 ),
-              ],
-            ),
+                label: 'Bottom',
+                variant: ButtonVariant.secondary,
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Stacking',
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                Button.small(
-                  onPressed: () {
-                    showToast(context: context, message: 'First', type: ToastType.success);
-                    Future.delayed(const Duration(milliseconds: 200), () {
-                      showToast(context: context, message: 'Second', type: ToastType.info);
-                    });
-                    Future.delayed(const Duration(milliseconds: 400), () {
-                      showToast(context: context, message: 'Third', type: ToastType.warning);
-                    });
-                  },
-                  label: 'Show 3 toasts',
-                  variant: ButtonVariant.primary,
-                ),
-                Button.small(
-                  onPressed: () => dismissAllToasts(),
-                  label: 'Dismiss all',
-                  variant: ButtonVariant.ghost,
-                ),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Stacking',
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              Button.small(
+                onPressed: () {
+                  showToast(context: context, message: 'First', type: ToastType.success);
+                  Future.delayed(const Duration(milliseconds: 200), () {
+                    showToast(context: context, message: 'Second', type: ToastType.info);
+                  });
+                  Future.delayed(const Duration(milliseconds: 400), () {
+                    showToast(context: context, message: 'Third', type: ToastType.warning);
+                  });
+                },
+                label: 'Show 3 toasts',
+                variant: ButtonVariant.primary,
+              ),
+              Button.small(
+                onPressed: () => dismissAllToasts(),
+                label: 'Dismiss all',
+                variant: ButtonVariant.ghost,
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/example/lib/pages/toggle_page.dart
+++ b/example/lib/pages/toggle_page.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:example/widgets/toggle.dart';
 
 class TogglePage extends StatefulWidget {
@@ -17,55 +16,52 @@ class _TogglePageState extends State<TogglePage> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSection(
-            title: 'Default',
-            child: Row(
-              children: [
-                Toggle(
-                  value: _default1,
-                  onChanged: (v) => setState(() => _default1 = v),
-                ),
-                const SizedBox(width: 16),
-                Toggle(
-                  value: _default2,
-                  onChanged: (v) => setState(() => _default2 = v),
-                ),
-              ],
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Default',
+          child: Row(
+            children: [
+              Toggle(
+                value: _default1,
+                onChanged: (v) => setState(() => _default1 = v),
+              ),
+              const SizedBox(width: 16),
+              Toggle(
+                value: _default2,
+                onChanged: (v) => setState(() => _default2 = v),
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Small',
-            child: Row(
-              children: [
-                Toggle.small(
-                  value: _small1,
-                  onChanged: (v) => setState(() => _small1 = v),
-                ),
-                const SizedBox(width: 16),
-                Toggle.small(
-                  value: _small2,
-                  onChanged: (v) => setState(() => _small2 = v),
-                ),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Small',
+          child: Row(
+            children: [
+              Toggle.small(
+                value: _small1,
+                onChanged: (v) => setState(() => _small1 = v),
+              ),
+              const SizedBox(width: 16),
+              Toggle.small(
+                value: _small2,
+                onChanged: (v) => setState(() => _small2 = v),
+              ),
+            ],
           ),
-          _buildSection(
-            title: 'Disabled',
-            child: Row(
-              children: [
-                const Toggle(value: false),
-                const SizedBox(width: 16),
-                const Toggle(value: true),
-              ],
-            ),
+        ),
+        _buildSection(
+          title: 'Disabled',
+          child: Row(
+            children: [
+              const Toggle(value: false),
+              const SizedBox(width: 16),
+              const Toggle(value: true),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## Summary

Restructures the example app from 11 individual nav items into a 2-tab layout.

## Changes

- Restructured playground into 2-tab navigation