### PR TITLE
feat: add `ToggleTile` widget

### DIFF
--- a/bin/orient_ui.dart
+++ b/bin/orient_ui.dart
@@ -22,6 +22,10 @@ final Map<String, ComponentInfo> components = {
   'popup': ComponentInfo('popup.dart'),
   'search_field': ComponentInfo('search_field.dart'),
   'toggle': ComponentInfo('toggle.dart'),
+  'toggle_tile': ComponentInfo(
+    'toggle_tile.dart',
+    dependencies: ['toggle'],
+  ),
 };
 
 void main(List<String> args) async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -139,8 +139,9 @@ class _PlaygroundShellState extends State<PlaygroundShell> {
 
             return Button.small(
               onPressed: () {
-                _brightnessNotifier.value =
-                    isDark ? Brightness.light : Brightness.dark;
+                _brightnessNotifier.value = isDark
+                    ? Brightness.light
+                    : Brightness.dark;
               },
               icon: Icon(
                 isDark ? Icons.light_mode : Icons.dark_mode,

--- a/example/lib/pages/components_page.dart
+++ b/example/lib/pages/components_page.dart
@@ -9,6 +9,7 @@ import 'package:example/pages/search_field_page.dart';
 import 'package:example/pages/spinner_page.dart';
 import 'package:example/pages/toast_page.dart';
 import 'package:example/pages/toggle_page.dart';
+import 'package:example/pages/toggle_tile_page.dart';
 import 'package:example/styling.dart';
 import 'package:flutter/widgets.dart';
 
@@ -24,6 +25,7 @@ class ComponentsPage extends StatelessWidget {
     final sections = [
       _componentSection('Button', styling, const ButtonPage()),
       _componentSection('Toggle', styling, const TogglePage()),
+      _componentSection('Toggle Tile', styling, const ToggleTilePage()),
       _componentSection('Copy Button', styling, const CopyButtonPage()),
       _componentSection('Search Field', styling, const SearchFieldPage()),
       _componentSection('Spinner', styling, const SpinnerPage()),

--- a/example/lib/pages/toggle_tile_page.dart
+++ b/example/lib/pages/toggle_tile_page.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/widgets.dart';
+import 'package:example/widgets/toggle_tile.dart';
+
+class ToggleTilePage extends StatefulWidget {
+  const ToggleTilePage({super.key});
+
+  @override
+  State<ToggleTilePage> createState() => _ToggleTilePageState();
+}
+
+class _ToggleTilePageState extends State<ToggleTilePage> {
+  bool _simple = false;
+  bool _bordered = true;
+  bool _filled = false;
+  bool _titleOnly = false;
+  bool _withLeading = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSection(
+          title: 'Simple',
+          child: ToggleTile(
+            title: 'Notifications',
+            subtitle: 'Receive push notifications',
+            value: _simple,
+            onChanged: (v) => setState(() => _simple = v),
+          ),
+        ),
+        _buildSection(
+          title: 'Bordered',
+          child: ToggleTile(
+            variant: ToggleTileVariant.bordered,
+            title: 'Dark Mode',
+            subtitle: 'Use dark theme across the app',
+            value: _bordered,
+            onChanged: (v) => setState(() => _bordered = v),
+          ),
+        ),
+        _buildSection(
+          title: 'Filled',
+          child: ToggleTile(
+            variant: ToggleTileVariant.filled,
+            title: 'Auto Update',
+            subtitle: 'Automatically install updates',
+            value: _filled,
+            onChanged: (v) => setState(() => _filled = v),
+          ),
+        ),
+        _buildSection(
+          title: 'Title Only',
+          child: ToggleTile(
+            variant: ToggleTileVariant.bordered,
+            title: 'Enable Feature',
+            value: _titleOnly,
+            onChanged: (v) => setState(() => _titleOnly = v),
+          ),
+        ),
+        _buildSection(
+          title: 'With Leading',
+          child: ToggleTile(
+            variant: ToggleTileVariant.bordered,
+            leading: const Text('\u2699', style: TextStyle(fontSize: 24)),
+            title: 'Settings',
+            subtitle: 'Manage your preferences',
+            value: _withLeading,
+            onChanged: (v) => setState(() => _withLeading = v),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSection({required String title, required Widget child}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF71717A),
+            ),
+          ),
+          const SizedBox(height: 12),
+          child,
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/styling.dart
+++ b/example/lib/styling.dart
@@ -24,6 +24,7 @@ const Color _lightPrimaryText = Color(0xFF2A2A2A);
 const Color _lightSecondaryText = Color(0xFFACAEAF);
 const Color _lightAccent = Color(0xFF18181B);
 const Color _lightAccentForeground = Color(0xFFFAFAFA);
+const Color _lightSurfaceContainer = Color(0xFFFAFAFA);
 
 // Light Theme - Button
 const Color _lightButtonPrimary = Color(0xFF18181B);
@@ -57,6 +58,7 @@ const Color _darkPrimaryText = Color(0xFFFAFAFA);
 const Color _darkSecondaryText = Color(0xFFB2B2B2);
 const Color _darkAccent = Color(0xFFFAFAFA);
 const Color _darkAccentForeground = Color(0xFF18181B);
+const Color _darkSurfaceContainer = Color(0xFF121212);
 
 // Dark Theme - Button
 const Color _darkButtonPrimary = Color(0xFFFAFAFA);
@@ -110,6 +112,7 @@ final ColorTokens _colorsLight = ColorTokens(
   secondaryText: _lightSecondaryText,
   accent: _lightAccent,
   accentForeground: _lightAccentForeground,
+  surfaceContainer: _lightSurfaceContainer,
   button: ButtonColors(
     primary: _lightButtonPrimary,
     primaryForeground: _lightButtonPrimaryForeground,
@@ -144,6 +147,7 @@ final ColorTokens _colorsDark = ColorTokens(
   secondaryText: _darkSecondaryText,
   accent: _darkAccent,
   accentForeground: _darkAccentForeground,
+  surfaceContainer: _darkSurfaceContainer,
   button: ButtonColors(
     primary: _darkButtonPrimary,
     primaryForeground: _darkButtonPrimaryForeground,
@@ -322,6 +326,7 @@ class ColorTokens {
   final Color secondaryText;
   final Color accent;
   final Color accentForeground;
+  final Color surfaceContainer;
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;
@@ -333,6 +338,7 @@ class ColorTokens {
     required this.secondaryText,
     required this.accent,
     required this.accentForeground,
+    required this.surfaceContainer,
     required this.button,
     required this.navigation,
     required this.toast,

--- a/example/lib/widgets/toggle_tile.dart
+++ b/example/lib/widgets/toggle_tile.dart
@@ -1,0 +1,149 @@
+import 'package:example/styling.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'toggle.dart';
+
+// Variants for the toggle tile appearance
+enum ToggleTileVariant { simple, bordered, filled }
+
+class ToggleTile extends StatefulWidget {
+  final Widget? leading;
+  final String title;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final ToggleTileVariant variant;
+
+  const ToggleTile({
+    super.key,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    required this.value,
+    this.onChanged,
+    this.variant = ToggleTileVariant.simple,
+  });
+
+  @override
+  State<ToggleTile> createState() => _ToggleTileState();
+}
+
+class _ToggleTileState extends State<ToggleTile> {
+  bool _isFocused = false;
+
+  bool get _isDisabled => widget.onChanged == null;
+
+  void _handleTap() {
+    widget.onChanged?.call(!widget.value);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.space) {
+      _handleTap();
+
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorTokens colors = Styling.of(context).colors;
+
+    // Decoration based on variant
+    BoxDecoration decoration = switch (widget.variant) {
+      ToggleTileVariant.simple => BoxDecoration(
+        borderRadius: BorderRadius.zero,
+      ),
+      ToggleTileVariant.bordered => BoxDecoration(
+        border: Border.all(color: colors.border, width: 1),
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+      ToggleTileVariant.filled => BoxDecoration(
+        color: colors.surfaceContainer,
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+    };
+
+    // Focus ring
+    if (_isFocused && !_isDisabled) {
+      decoration = decoration.copyWith(
+        boxShadow: [
+          BoxShadow(
+            color: colors.accent.withValues(alpha: 0.4),
+            spreadRadius: 2,
+          ),
+        ],
+      );
+    }
+
+    return Semantics(
+      toggled: widget.value,
+      excludeSemantics: true,
+      child: Focus(
+        onFocusChange: (focused) {
+          setState(() {
+            _isFocused = focused;
+          });
+        },
+        onKeyEvent: _isDisabled ? null : _handleKeyEvent,
+        child: MouseRegion(
+          cursor: _isDisabled
+              ? SystemMouseCursors.basic
+              : SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: _isDisabled ? null : _handleTap,
+            behavior: HitTestBehavior.translucent,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              decoration: decoration,
+              child: Row(
+                children: [
+                  if (widget.leading != null) ...[
+                    widget.leading!,
+                    const SizedBox(width: 12),
+                  ],
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: TextStyle(
+                            fontSize: 16,
+                            height: 1.5,
+                            fontWeight: FontWeight.w500,
+                            color: colors.primaryText,
+                          ),
+                        ),
+                        if (widget.subtitle != null)
+                          Text(
+                            widget.subtitle!,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 14,
+                              height: 20 / 14,
+                              color: colors.secondaryText,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Toggle(
+                    value: widget.value,
+                    onChanged: widget.onChanged,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/test/toggle_tile_test.dart
+++ b/example/test/toggle_tile_test.dart
@@ -1,0 +1,384 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:example/widgets/toggle.dart';
+import 'package:example/widgets/toggle_tile.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  group('ToggleTile', () {
+    group('rendering', () {
+      testWidgets('renders title', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Notifications',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.text('Notifications'), findsOneWidget);
+      });
+
+      testWidgets('renders subtitle', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Notifications',
+            subtitle: 'Receive push notifications',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.text('Receive push notifications'), findsOneWidget);
+      });
+
+      testWidgets('renders without subtitle', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Notifications',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.text('Notifications'), findsOneWidget);
+        expect(find.text('Receive push notifications'), findsNothing);
+      });
+
+      testWidgets('renders Toggle widget', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Notifications',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.byType(Toggle), findsOneWidget);
+      });
+
+      testWidgets('renders simple variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.byType(ToggleTile), findsOneWidget);
+      });
+
+      testWidgets('renders bordered variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.bordered,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.byType(ToggleTile), findsOneWidget);
+      });
+
+      testWidgets('renders filled variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.filled,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.byType(ToggleTile), findsOneWidget);
+      });
+
+      testWidgets('renders with leading widget', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            leading: const Text('L'),
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.text('L'), findsOneWidget);
+      });
+
+      testWidgets('renders without leading widget', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        // No leading, no 12px gap SizedBox before text
+        expect(find.text('Test'), findsOneWidget);
+      });
+    });
+
+    group('variants', () {
+      testWidgets('simple has no border or fill', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.border, isNull);
+        expect(decoration.color, isNull);
+      });
+
+      testWidgets('bordered has border', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.bordered,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.border, isNotNull);
+      });
+
+      testWidgets('filled has surfaceContainer color', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.filled,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, const Color(0xFFFAFAFA));
+      });
+
+      testWidgets('filled dark mode uses dark surfaceContainer', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.filled,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+          brightness: Brightness.dark,
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, const Color(0xFF121212));
+      });
+    });
+
+    group('interaction', () {
+      testWidgets('tap toggles value', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.byType(ToggleTile));
+        await tester.pump();
+
+        expect(received, isTrue);
+      });
+
+      testWidgets('tap on text area toggles', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            subtitle: 'A subtitle',
+            value: false,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.text('Test'));
+        await tester.pump();
+
+        expect(received, isTrue);
+      });
+
+      testWidgets('tap on toggle area toggles', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.byType(Toggle));
+        await tester.pump();
+
+        expect(received, isTrue);
+      });
+
+      testWidgets('callback receives correct value when toggling off', (tester) async {
+        bool? received;
+
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: true,
+            onChanged: (v) => received = v,
+          ),
+        ));
+
+        await tester.tap(find.byType(ToggleTile));
+        await tester.pump();
+
+        expect(received, isFalse);
+      });
+
+      testWidgets('hover shows click cursor', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final mouseRegion = tester.widget<MouseRegion>(
+          find.byType(MouseRegion).first,
+        );
+        expect(mouseRegion.cursor, SystemMouseCursors.click);
+      });
+    });
+
+    group('subtitle', () {
+      testWidgets('supports max 2 lines with ellipsis', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            subtitle: 'This is a very long subtitle that should wrap to '
+                'multiple lines and eventually get truncated with an '
+                'ellipsis when it exceeds the maximum of two lines',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final subtitleWidget = tester.widget<Text>(find.text(
+          'This is a very long subtitle that should wrap to '
+          'multiple lines and eventually get truncated with an '
+          'ellipsis when it exceeds the maximum of two lines',
+        ));
+        expect(subtitleWidget.maxLines, 2);
+        expect(subtitleWidget.overflow, TextOverflow.ellipsis);
+      });
+
+      testWidgets('renders single line subtitle', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            subtitle: 'Short',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        expect(find.text('Short'), findsOneWidget);
+      });
+    });
+
+    group('accessibility', () {
+      testWidgets('has toggled semantics when on', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: true,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(ToggleTile));
+        expect(semantics.hasFlag(SemanticsFlag.isToggled), isTrue);
+      });
+
+      testWidgets('does not have toggled semantics when off', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final semantics = tester.getSemantics(find.byType(ToggleTile));
+        expect(semantics.hasFlag(SemanticsFlag.isToggled), isFalse);
+      });
+    });
+
+    group('theming', () {
+      testWidgets('renders in light mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: true,
+            onChanged: (v) {},
+          ),
+          brightness: Brightness.light,
+        ));
+
+        expect(find.byType(ToggleTile), findsOneWidget);
+      });
+
+      testWidgets('renders in dark mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            title: 'Test',
+            value: true,
+            onChanged: (v) {},
+          ),
+          brightness: Brightness.dark,
+        ));
+
+        expect(find.byType(ToggleTile), findsOneWidget);
+      });
+
+      testWidgets('filled uses surfaceContainer color', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          ToggleTile(
+            variant: ToggleTileVariant.filled,
+            title: 'Test',
+            value: false,
+            onChanged: (v) {},
+          ),
+        ));
+
+        final container = tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, isNotNull);
+      });
+    });
+  });
+}

--- a/templates/styling.dart
+++ b/templates/styling.dart
@@ -24,6 +24,7 @@ const Color _lightPrimaryText = Color(0xFF2A2A2A);
 const Color _lightSecondaryText = Color(0xFFACAEAF);
 const Color _lightAccent = Color(0xFF18181B);
 const Color _lightAccentForeground = Color(0xFFFAFAFA);
+const Color _lightSurfaceContainer = Color(0xFFFAFAFA);
 
 // Light Theme - Button
 const Color _lightButtonPrimary = Color(0xFF18181B);
@@ -57,6 +58,7 @@ const Color _darkPrimaryText = Color(0xFFFAFAFA);
 const Color _darkSecondaryText = Color(0xFFB2B2B2);
 const Color _darkAccent = Color(0xFFFAFAFA);
 const Color _darkAccentForeground = Color(0xFF18181B);
+const Color _darkSurfaceContainer = Color(0xFF121212);
 
 // Dark Theme - Button
 const Color _darkButtonPrimary = Color(0xFFFAFAFA);
@@ -110,6 +112,7 @@ final ColorTokens _colorsLight = ColorTokens(
   secondaryText: _lightSecondaryText,
   accent: _lightAccent,
   accentForeground: _lightAccentForeground,
+  surfaceContainer: _lightSurfaceContainer,
   button: ButtonColors(
     primary: _lightButtonPrimary,
     primaryForeground: _lightButtonPrimaryForeground,
@@ -144,6 +147,7 @@ final ColorTokens _colorsDark = ColorTokens(
   secondaryText: _darkSecondaryText,
   accent: _darkAccent,
   accentForeground: _darkAccentForeground,
+  surfaceContainer: _darkSurfaceContainer,
   button: ButtonColors(
     primary: _darkButtonPrimary,
     primaryForeground: _darkButtonPrimaryForeground,
@@ -322,6 +326,7 @@ class ColorTokens {
   final Color secondaryText;
   final Color accent;
   final Color accentForeground;
+  final Color surfaceContainer;
   final ButtonColors button;
   final NavigationColors navigation;
   final ToastColors toast;
@@ -333,6 +338,7 @@ class ColorTokens {
     required this.secondaryText,
     required this.accent,
     required this.accentForeground,
+    required this.surfaceContainer,
     required this.button,
     required this.navigation,
     required this.toast,

--- a/templates/toggle_tile.dart
+++ b/templates/toggle_tile.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'styling.dart';
+import 'toggle.dart';
+
+// Variants for the toggle tile appearance
+enum ToggleTileVariant { simple, bordered, filled }
+
+class ToggleTile extends StatefulWidget {
+  final Widget? leading;
+  final String title;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final ToggleTileVariant variant;
+
+  const ToggleTile({
+    super.key,
+    this.leading,
+    required this.title,
+    this.subtitle,
+    required this.value,
+    this.onChanged,
+    this.variant = ToggleTileVariant.simple,
+  });
+
+  @override
+  State<ToggleTile> createState() => _ToggleTileState();
+}
+
+class _ToggleTileState extends State<ToggleTile> {
+  bool _isFocused = false;
+
+  bool get _isDisabled => widget.onChanged == null;
+
+  void _handleTap() {
+    widget.onChanged?.call(!widget.value);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.space) {
+      _handleTap();
+
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorTokens colors = Styling.of(context).colors;
+
+    // Decoration based on variant
+    BoxDecoration decoration = switch (widget.variant) {
+      ToggleTileVariant.simple => BoxDecoration(
+        borderRadius: BorderRadius.zero,
+      ),
+      ToggleTileVariant.bordered => BoxDecoration(
+        border: Border.all(color: colors.border, width: 1),
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+      ToggleTileVariant.filled => BoxDecoration(
+        color: colors.surfaceContainer,
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+    };
+
+    // Focus ring
+    if (_isFocused && !_isDisabled) {
+      decoration = decoration.copyWith(
+        boxShadow: [
+          BoxShadow(
+            color: colors.accent.withValues(alpha: 0.4),
+            spreadRadius: 2,
+          ),
+        ],
+      );
+    }
+
+    return Semantics(
+      toggled: widget.value,
+      excludeSemantics: true,
+      child: Focus(
+        onFocusChange: (focused) {
+          setState(() {
+            _isFocused = focused;
+          });
+        },
+        onKeyEvent: _isDisabled ? null : _handleKeyEvent,
+        child: MouseRegion(
+          cursor: _isDisabled
+              ? SystemMouseCursors.basic
+              : SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: _isDisabled ? null : _handleTap,
+            behavior: HitTestBehavior.translucent,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              decoration: decoration,
+              child: Row(
+                children: [
+                  if (widget.leading != null) ...[
+                    widget.leading!,
+                    const SizedBox(width: 12),
+                  ],
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: TextStyle(
+                            fontSize: 16,
+                            height: 1.5,
+                            fontWeight: FontWeight.w500,
+                            color: colors.primaryText,
+                          ),
+                        ),
+                        if (widget.subtitle != null)
+                          Text(
+                            widget.subtitle!,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 14,
+                              height: 20 / 14,
+                              color: colors.secondaryText,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Toggle(
+                    value: widget.value,
+                    onChanged: widget.onChanged,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

A compound widget that combines a title, optional subtitle, optional leading widget, and the existing Toggle into a single tappable tile. Supports three visual variants: simple, bordered, and filled.

## Changes

- Added `surfaceContainer` color token to the styling system
- Created `ToggleTile` widget template and example page
- Registered the component in CLI with a toggle dependency
- Added widget tests