### PR TITLE
feat: add `CardBox` widget

### DIFF
--- a/bin/orient_ui.dart
+++ b/bin/orient_ui.dart
@@ -12,6 +12,7 @@ final Map<String, ComponentInfo> components = {
     'button.dart',
     dependencies: ['spinner'],
   ),
+  'card_box': ComponentInfo('card_box.dart'),
   'confirmation_popup': ComponentInfo(
     'confirmation_popup.dart',
     dependencies: ['button'],

--- a/example/lib/pages/card_box_page.dart
+++ b/example/lib/pages/card_box_page.dart
@@ -1,0 +1,272 @@
+import 'package:example/styling.dart';
+import 'package:example/widgets/card_box.dart';
+import 'package:example/widgets/demo_section.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+
+class CardBoxPage extends StatelessWidget {
+  const CardBoxPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Styling.of(context).colors;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Stats card — dashboard KPI style
+        DemoSection(
+          title: 'Bordered',
+          child: CardBox(
+            child: Row(
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    color: colors.surfaceContainer,
+                    borderRadius:
+                        BorderRadius.circular(Styling.radii.small),
+                  ),
+                  child: Center(
+                    child: Icon(
+                      TablerIcons.chart_bar,
+                      size: 22,
+                      color: colors.primaryText,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Monthly Revenue',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: colors.secondaryText,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '\$12,840',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.w700,
+                          color: colors.primaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF22C55E).withValues(alpha: 0.12),
+                    borderRadius:
+                        BorderRadius.circular(Styling.radii.small),
+                  ),
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        TablerIcons.trending_up,
+                        size: 14,
+                        color: Color(0xFF22C55E),
+                      ),
+                      SizedBox(width: 4),
+                      Text(
+                        '+14%',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF22C55E),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // Pricing cards — side by side
+        DemoSection(
+          title: 'Filled',
+          child: Row(
+            children: [
+              Expanded(
+                child: CardBox(
+                  variant: CardBoxVariant.filled,
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Pro',
+                        style: TextStyle(
+                          fontSize: 17,
+                          fontWeight: FontWeight.w700,
+                          color: colors.primaryText,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '\$29/mo',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: colors.secondaryText,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      _featureRow(colors, TablerIcons.check, '10 projects'),
+                      const SizedBox(height: 6),
+                      _featureRow(colors, TablerIcons.check, 'Email support'),
+                      const SizedBox(height: 6),
+                      _featureRow(colors, TablerIcons.check, '5 GB storage'),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: CardBox(
+                  variant: CardBoxVariant.filled,
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            'Enterprise',
+                            style: TextStyle(
+                              fontSize: 17,
+                              fontWeight: FontWeight.w700,
+                              color: colors.primaryText,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: colors.accent,
+                              borderRadius:
+                                  BorderRadius.circular(Styling.radii.small),
+                            ),
+                            child: Text(
+                              'Popular',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: colors.accentForeground,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        '\$99/mo',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: colors.secondaryText,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      _featureRow(colors, TablerIcons.check, 'Unlimited'),
+                      const SizedBox(height: 6),
+                      _featureRow(colors, TablerIcons.check, 'Priority support'),
+                      const SizedBox(height: 6),
+                      _featureRow(colors, TablerIcons.check, '100 GB storage'),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        // Clickable notification card
+        DemoSection(
+          title: 'Clickable',
+          child: CardBox(
+            onTap: () {},
+            padding: const EdgeInsets.all(20),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF3B82F6).withValues(alpha: 0.12),
+                    borderRadius:
+                        BorderRadius.circular(Styling.radii.small),
+                  ),
+                  child: const Center(
+                    child: Icon(
+                      TablerIcons.bell,
+                      size: 18,
+                      color: Color(0xFF3B82F6),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'New deployment succeeded',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: colors.primaryText,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Production build v2.4.1 deployed 3 min ago.',
+                        style: TextStyle(
+                          fontSize: 13,
+                          height: 1.4,
+                          color: colors.secondaryText,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  TablerIcons.chevron_right,
+                  size: 18,
+                  color: colors.secondaryText,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _featureRow(ColorTokens colors, IconData icon, String text) {
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: colors.primaryText),
+        const SizedBox(width: 8),
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: 14,
+            color: colors.primaryText,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/pages/card_box_page.dart
+++ b/example/lib/pages/card_box_page.dart
@@ -93,101 +93,118 @@ class CardBoxPage extends StatelessWidget {
           ),
         ),
 
-        // Pricing cards — side by side
+        // Pricing cards — row on desktop, column on mobile
         DemoSection(
           title: 'Filled',
-          child: Row(
-            children: [
-              Expanded(
-                child: CardBox(
-                  variant: CardBoxVariant.filled,
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Pro',
-                        style: TextStyle(
-                          fontSize: 17,
-                          fontWeight: FontWeight.w700,
-                          color: colors.primaryText,
-                        ),
+          child: Builder(
+            builder: (context) {
+              final isDesktop = MediaQuery.of(context).size.width >=
+                  Styling.breakpoints.desktop;
+
+              final proCard = CardBox(
+                variant: CardBoxVariant.filled,
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Pro',
+                      style: TextStyle(
+                        fontSize: 17,
+                        fontWeight: FontWeight.w700,
+                        color: colors.primaryText,
                       ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '\$29/mo',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: colors.secondaryText,
-                        ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '\$29/mo',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: colors.secondaryText,
                       ),
-                      const SizedBox(height: 14),
-                      _featureRow(colors, TablerIcons.check, '10 projects'),
-                      const SizedBox(height: 6),
-                      _featureRow(colors, TablerIcons.check, 'Email support'),
-                      const SizedBox(height: 6),
-                      _featureRow(colors, TablerIcons.check, '5 GB storage'),
-                    ],
-                  ),
+                    ),
+                    const SizedBox(height: 14),
+                    _featureRow(colors, TablerIcons.check, '10 projects'),
+                    const SizedBox(height: 6),
+                    _featureRow(colors, TablerIcons.check, 'Email support'),
+                    const SizedBox(height: 6),
+                    _featureRow(colors, TablerIcons.check, '5 GB storage'),
+                  ],
                 ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: CardBox(
-                  variant: CardBoxVariant.filled,
-                  padding: const EdgeInsets.all(20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Text(
-                            'Enterprise',
+              );
+
+              final enterpriseCard = CardBox(
+                variant: CardBoxVariant.filled,
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          'Enterprise',
+                          style: TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w700,
+                            color: colors.primaryText,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: colors.accent,
+                            borderRadius:
+                                BorderRadius.circular(Styling.radii.small),
+                          ),
+                          child: Text(
+                            'Popular',
                             style: TextStyle(
-                              fontSize: 17,
-                              fontWeight: FontWeight.w700,
-                              color: colors.primaryText,
+                              fontSize: 10,
+                              fontWeight: FontWeight.w600,
+                              color: colors.accentForeground,
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 6, vertical: 2),
-                            decoration: BoxDecoration(
-                              color: colors.accent,
-                              borderRadius:
-                                  BorderRadius.circular(Styling.radii.small),
-                            ),
-                            child: Text(
-                              'Popular',
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: FontWeight.w600,
-                                color: colors.accentForeground,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        '\$99/mo',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: colors.secondaryText,
                         ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '\$99/mo',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: colors.secondaryText,
                       ),
-                      const SizedBox(height: 14),
-                      _featureRow(colors, TablerIcons.check, 'Unlimited'),
-                      const SizedBox(height: 6),
-                      _featureRow(colors, TablerIcons.check, 'Priority support'),
-                      const SizedBox(height: 6),
-                      _featureRow(colors, TablerIcons.check, '100 GB storage'),
-                    ],
-                  ),
+                    ),
+                    const SizedBox(height: 14),
+                    _featureRow(colors, TablerIcons.check, 'Unlimited projects'),
+                    const SizedBox(height: 6),
+                    _featureRow(colors, TablerIcons.check, 'Priority support'),
+                    const SizedBox(height: 6),
+                    _featureRow(colors, TablerIcons.check, '100 GB storage'),
+                  ],
                 ),
-              ),
-            ],
+              );
+
+              if (isDesktop) {
+                return Row(
+                  children: [
+                    Expanded(child: proCard),
+                    const SizedBox(width: 12),
+                    Expanded(child: enterpriseCard),
+                  ],
+                );
+              }
+
+              return Column(
+                children: [
+                  proCard,
+                  const SizedBox(height: 12),
+                  enterpriseCard,
+                ],
+              );
+            },
           ),
         ),
 
@@ -259,11 +276,13 @@ class CardBoxPage extends StatelessWidget {
       children: [
         Icon(icon, size: 16, color: colors.primaryText),
         const SizedBox(width: 8),
-        Text(
-          text,
-          style: TextStyle(
-            fontSize: 14,
-            color: colors.primaryText,
+        Flexible(
+          child: Text(
+            text,
+            style: TextStyle(
+              fontSize: 14,
+              color: colors.primaryText,
+            ),
           ),
         ),
       ],

--- a/example/lib/pages/components_page.dart
+++ b/example/lib/pages/components_page.dart
@@ -1,5 +1,6 @@
 import 'package:example/pages/alert_popup_page.dart';
 import 'package:example/pages/button_page.dart';
+import 'package:example/pages/card_box_page.dart';
 import 'package:example/pages/confirmation_popup_page.dart';
 import 'package:example/pages/copy_button_page.dart';
 import 'package:example/pages/empty_state_page.dart';
@@ -24,6 +25,7 @@ class ComponentsPage extends StatelessWidget {
         MediaQuery.of(context).size.width >= Styling.breakpoints.desktop;
 
     final sections = [
+      _componentSection('CardBox', 'card_box', styling, const CardBoxPage()),
       _componentSection('Button', 'button', styling, const ButtonPage()),
       _componentSection('Toggle', 'toggle', styling, const TogglePage()),
       _componentSection('Tile', 'tile', styling, const TilePage()),

--- a/example/lib/widgets/card_box.dart
+++ b/example/lib/widgets/card_box.dart
@@ -1,0 +1,55 @@
+import 'package:example/styling.dart';
+import 'package:flutter/widgets.dart';
+
+enum CardBoxVariant { bordered, filled }
+
+class CardBox extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final CardBoxVariant variant;
+  final VoidCallback? onTap;
+
+  const CardBox({
+    super.key,
+    required this.child,
+    this.padding,
+    this.variant = CardBoxVariant.filled,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorTokens colors = Styling.of(context).colors;
+
+    final BoxDecoration decoration = switch (variant) {
+      CardBoxVariant.bordered => BoxDecoration(
+        border: Border.all(color: colors.border, width: 1),
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+      CardBoxVariant.filled => BoxDecoration(
+        color: colors.surfaceContainer,
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+    };
+
+    Widget card = Container(
+      width: double.infinity,
+      padding: padding ?? const EdgeInsets.all(16),
+      decoration: decoration,
+      child: child,
+    );
+
+    if (onTap != null) {
+      card = MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.opaque,
+          child: card,
+        ),
+      );
+    }
+
+    return card;
+  }
+}

--- a/example/test/card_box_test.dart
+++ b/example/test/card_box_test.dart
@@ -1,0 +1,143 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:example/widgets/card_box.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  group('CardBox', () {
+    group('rendering', () {
+      testWidgets('renders child', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Hello'),
+          ),
+        ));
+
+        expect(find.text('Hello'), findsOneWidget);
+      });
+
+      testWidgets('renders bordered variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Bordered'),
+          ),
+        ));
+
+        final container =
+            tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.border, isNotNull);
+        expect(decoration.color, isNull);
+      });
+
+      testWidgets('renders filled variant', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            variant: CardBoxVariant.filled,
+            child: Text('Filled'),
+          ),
+        ));
+
+        final container =
+            tester.widget<Container>(find.byType(Container).first);
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, isNotNull);
+        expect(decoration.border, isNull);
+      });
+
+      testWidgets('uses default padding', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Default'),
+          ),
+        ));
+
+        final container =
+            tester.widget<Container>(find.byType(Container).first);
+        expect(container.padding, const EdgeInsets.all(16));
+      });
+
+      testWidgets('uses custom padding', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            padding: EdgeInsets.all(32),
+            child: Text('Custom'),
+          ),
+        ));
+
+        final container =
+            tester.widget<Container>(find.byType(Container).first);
+        expect(container.padding, const EdgeInsets.all(32));
+      });
+    });
+
+    group('interaction', () {
+      testWidgets('tap triggers onTap', (tester) async {
+        bool tapped = false;
+
+        await tester.pumpWidget(wrapWithStyling(
+          CardBox(
+            onTap: () => tapped = true,
+            child: const Text('Tap me'),
+          ),
+        ));
+
+        await tester.tap(find.byType(CardBox));
+        await tester.pump();
+
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('shows click cursor when tappable', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          CardBox(
+            onTap: () {},
+            child: const Text('Clickable'),
+          ),
+        ));
+
+        final mouseRegion = tester.widget<MouseRegion>(
+          find.byType(MouseRegion).first,
+        );
+        expect(mouseRegion.cursor, SystemMouseCursors.click);
+      });
+
+      testWidgets('no MouseRegion when not tappable', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Static'),
+          ),
+        ));
+
+        expect(find.byType(MouseRegion), findsNothing);
+      });
+    });
+
+    group('theming', () {
+      testWidgets('renders in light mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Light'),
+          ),
+          brightness: Brightness.light,
+        ));
+
+        expect(find.byType(CardBox), findsOneWidget);
+      });
+
+      testWidgets('renders in dark mode', (tester) async {
+        await tester.pumpWidget(wrapWithStyling(
+          const CardBox(
+            child: Text('Dark'),
+          ),
+          brightness: Brightness.dark,
+        ));
+
+        expect(find.byType(CardBox), findsOneWidget);
+      });
+    });
+  });
+}

--- a/templates/card_box.dart
+++ b/templates/card_box.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/widgets.dart';
+
+import 'styling.dart';
+
+enum CardBoxVariant { bordered, filled }
+
+class CardBox extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final CardBoxVariant variant;
+  final VoidCallback? onTap;
+
+  const CardBox({
+    super.key,
+    required this.child,
+    this.padding,
+    this.variant = CardBoxVariant.filled,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorTokens colors = Styling.of(context).colors;
+
+    final BoxDecoration decoration = switch (variant) {
+      CardBoxVariant.bordered => BoxDecoration(
+        border: Border.all(color: colors.border, width: 1),
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+      CardBoxVariant.filled => BoxDecoration(
+        color: colors.surfaceContainer,
+        borderRadius: BorderRadius.circular(Styling.radii.medium),
+      ),
+    };
+
+    Widget card = Container(
+      width: double.infinity,
+      padding: padding ?? const EdgeInsets.all(16),
+      decoration: decoration,
+      child: child,
+    );
+
+    if (onTap != null) {
+      card = MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.opaque,
+          child: card,
+        ),
+      );
+    }
+
+    return card;
+  }
+}


### PR DESCRIPTION
## Summary

- Added new `CardBox` widget. It's what we know from Material as `Card`. Distinctively, it has two modes: bordered and filled (default). Filled one looks pretty cool.